### PR TITLE
fix: improve mobile table responsiveness in query pages

### DIFF
--- a/src/pages/FissionQuery.tsx
+++ b/src/pages/FissionQuery.tsx
@@ -506,7 +506,7 @@ export default function FissionQuery() {
               </div>
             </div>
 
-            <div className="table-container">
+            <div className="table-container -mx-6 sm:mx-0">
               <table className="data-table">
                 <thead>
                   <tr>

--- a/src/pages/FusionQuery.tsx
+++ b/src/pages/FusionQuery.tsx
@@ -521,7 +521,7 @@ export default function FusionQuery() {
               </div>
             </div>
 
-            <div className="table-container">
+            <div className="table-container -mx-6 sm:mx-0">
               <table className="data-table">
                 <thead>
                   <tr>

--- a/src/pages/TwoToTwoQuery.tsx
+++ b/src/pages/TwoToTwoQuery.tsx
@@ -545,7 +545,7 @@ export default function TwoToTwoQuery() {
               </div>
             </div>
 
-            <div className="table-container">
+            <div className="table-container -mx-6 sm:mx-0">
               <table className="data-table">
                 <thead>
                   <tr>


### PR DESCRIPTION
## Summary
Fixes horizontal overflow issues in result tables on mobile devices across all three query pages.

## Changes
- Applied `-mx-6 sm:mx-0` pattern to table containers in Fusion, Fission, and TwoToTwo query pages
- Tables now break out of card padding on mobile for full-width scrolling
- Desktop behavior unchanged

## Screenshots

### Mobile Fusion Table Responsiveness
![Fusion query page showing mobile table with horizontal scrolling](https://db.lenr.academy/screenshots/pr/pr-31-mobile-fusion-v3.png)

*Fusion query interface on mobile viewport (640x360) demonstrating improved table overflow handling. The table displays INPUT 1, INPUT 2, OUTPUT, ENERGY (MeV), and NEUTRINO columns with proper horizontal scrolling enabled through the `-mx-6 sm:mx-0` pattern.*

## Testing
- ✅ Verified on mobile viewport (640x360 - mobile-16:9)
- ✅ Tested horizontal scrolling with result tables
- ✅ Confirmed no regression on desktop
- ✅ Verified across Fusion, Fission, and TwoToTwo query pages

## Technical Details

The fix uses Tailwind's negative margin pattern to allow tables to break out of their parent card padding on mobile:
- `-mx-6`: Negative horizontal margin on mobile to extend beyond card padding
- `sm:mx-0`: Reset margins to zero on small screens and above (desktop)

This ensures tables have full viewport width for horizontal scrolling on mobile while maintaining proper card alignment on desktop.

## Related Issues
General UX improvement - no specific issue