### PR TITLE
Feature: Enhanced search with element names and daughter nuclides

### DIFF
--- a/src/components/SortableTable.tsx
+++ b/src/components/SortableTable.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, ReactNode } from 'react'
 import { ChevronUp, ChevronDown, ChevronsUpDown, ChevronRight } from 'lucide-react'
-import { filterDataBySearch } from '../utils/searchUtils'
+import { filterDataBySearch, SearchMetadata } from '../utils/searchUtils'
 
 export interface TableColumn<T> {
   key: string
@@ -16,6 +16,7 @@ interface SortableTableProps<T> {
   columns: TableColumn<T>[]
   onRowClick?: (row: T) => void
   searchTerm?: string  // Optional: for backward compatibility, search is now handled by FilterPanel
+  searchMetadata?: SearchMetadata  // Optional: metadata for enhanced searching (element names, daughter nuclides)
   className?: string
   emptyMessage?: string
   renderExpandedContent?: (row: T) => ReactNode  // Optional: render function for expandable row content
@@ -31,6 +32,7 @@ export default function SortableTable<T extends Record<string, any>>({
   columns,
   onRowClick,
   searchTerm,
+  searchMetadata,
   className = '',
   emptyMessage = 'No data available',
   renderExpandedContent,
@@ -78,7 +80,7 @@ export default function SortableTable<T extends Record<string, any>>({
 
     // Apply search filter if searchTerm provided (using utility function)
     if (searchTerm) {
-      result = filterDataBySearch(result, columns, searchTerm)
+      result = filterDataBySearch(result, columns, searchTerm, searchMetadata)
     }
 
     // Apply sorting (if search prioritization isn't active or as secondary sort)
@@ -106,7 +108,7 @@ export default function SortableTable<T extends Record<string, any>>({
     }
 
     return result
-  }, [data, sortKey, sortDirection, searchTerm, columns])
+  }, [data, sortKey, sortDirection, searchTerm, searchMetadata, columns])
 
   return (
     <div className={className}>

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -3,6 +3,23 @@
  */
 
 /**
+ * Element info for name-based searching
+ */
+export interface ElementInfo {
+  symbol: string;  // E.g., "He"
+  name: string;    // E.g., "Helium"
+  Z: number;       // Atomic number
+}
+
+/**
+ * Metadata for enhanced searching with element names and daughter nuclides
+ */
+export interface SearchMetadata {
+  elements?: ElementInfo[];  // Array of elements with symbol, name, and Z
+  daughterNuclideGetter?: (row: any) => { E?: string; Z?: number; A?: number } | null;  // Function to get daughter nuclide from row
+}
+
+/**
  * Parse nuclide notation (In-49, In49, in-49, in49) to extract element and mass number
  */
 export function parseNuclideNotation(search: string): { element?: string; massNumber?: number } | null {
@@ -15,6 +32,23 @@ export function parseNuclideNotation(search: string): { element?: string; massNu
     }
   }
   return null
+}
+
+/**
+ * Find element symbols that match a search term against element names
+ * Returns Map of element symbol to match score
+ */
+export function findElementsByName(search: string, elements: ElementInfo[]): Map<string, number> {
+  const matches = new Map<string, number>()
+
+  elements.forEach(el => {
+    const score = getMatchScore(el.name, search)
+    if (score > 0) {
+      matches.set(el.symbol, score)
+    }
+  })
+
+  return matches
 }
 
 /**
@@ -66,21 +100,30 @@ export function getMatchScore(value: string, search: string): number {
 /**
  * Filter and sort data by search term with priority-based matching
  * Supports nuclide notation (In-49, In49) for data with 'E' and 'A' columns
+ * Supports element name searching when metadata is provided
+ * Supports daughter nuclide searching for decay data when metadata is provided
  */
 export function filterDataBySearch<T extends Record<string, any>>(
   data: T[],
   columns: Array<{ key: string }>,
-  searchTerm: string
+  searchTerm: string,
+  metadata?: SearchMetadata
 ): T[] {
   if (!searchTerm) return data
 
   const nuclideMatch = parseNuclideNotation(searchTerm)
 
+  // Find element symbols that match the search term by name (returns Map of symbol → score)
+  let elementNameScores = new Map<string, number>()
+  if (metadata?.elements) {
+    elementNameScores = findElementsByName(searchTerm, metadata.elements)
+  }
+
   // Create array of {row, score} for priority sorting
   const scoredResults = data.map(row => {
     let maxScore = 0
 
-    // Check for nuclide notation match (In-49, In49, etc.)
+    // Check for nuclide notation match (In-49, In49, etc.) - PARENT nuclide
     if (nuclideMatch) {
       const rowE = row['E'] || row['element']
       const rowA = row['A']
@@ -89,12 +132,43 @@ export function filterDataBySearch<T extends Record<string, any>>(
       if (rowE && rowA !== undefined) {
         const elementMatch = getMatchScore(String(rowE), nuclideMatch.element || '')
         if (elementMatch > 0 && rowA === nuclideMatch.massNumber) {
-          maxScore = Math.max(maxScore, 1500) // Very high priority for nuclide notation
+          maxScore = Math.max(maxScore, 3500) // Highest priority for parent nuclide notation
         }
       }
     }
 
-    // Check all columns for matches
+    // Check if element symbol matches element name search - PARENT
+    if (elementNameScores.size > 0) {
+      const rowE = row['E'] || row['element']
+      const nameScore = elementNameScores.get(String(rowE))
+      if (nameScore !== undefined) {
+        // Base of 2000 + actual name match score (0-1000) = 2000-3000 range
+        maxScore = Math.max(maxScore, 2000 + nameScore)
+      }
+    }
+
+    // Check for nuclide notation match - DAUGHTER nuclide (decays only)
+    if (nuclideMatch && metadata?.daughterNuclideGetter) {
+      const daughter = metadata.daughterNuclideGetter(row)
+      if (daughter && daughter.E && daughter.A !== undefined) {
+        const elementMatch = getMatchScore(String(daughter.E), nuclideMatch.element || '')
+        if (elementMatch > 0 && daughter.A === nuclideMatch.massNumber) {
+          maxScore = Math.max(maxScore, 1500) // Medium priority for daughter nuclide notation
+        }
+      }
+    }
+
+    // Check if element symbol matches element name search - DAUGHTER (decays only)
+    if (elementNameScores.size > 0 && metadata?.daughterNuclideGetter) {
+      const daughter = metadata.daughterNuclideGetter(row)
+      const nameScore = daughter?.E ? elementNameScores.get(String(daughter.E)) : undefined
+      if (nameScore !== undefined) {
+        // Base of 1000 + actual name match score for daughter (1000-2000 range)
+        maxScore = Math.max(maxScore, 1000 + nameScore)
+      }
+    }
+
+    // Check all columns for matches (including Z, A, etc.)
     columns.forEach(col => {
       const value = row[col.key]
       if (value != null) {


### PR DESCRIPTION
Fixes #47

## Summary

Enhances the search functionality in the Element Data page (Decays tab and other data tables) to support searching by element names and daughter nuclide notation, with intelligent priority-based result ranking.

## Changes

### New Search Capabilities

**Element Name Searching:**
- Search by full element name: "Francium", "Carbon", "Iron"
- Case-insensitive and fuzzy matching
- Works across all tabs (Elements, Nuclides, Decays)

**Nuclide Notation:**
- Support formats: "C-14", "c14", "C14", "c-14"
- Matches both parent and daughter nuclides (in decay data)
- Higher priority for exact notation matches

**Intelligent Result Ranking:**
Results are scored and sorted by match quality:
- **Parent nuclide notation** (Fr-223): 3500 points
- **Parent element name** (Francium): 2000-3000 points
- **Daughter nuclide notation**: 1500 points
- **Daughter element name**: 1000-2000 points
- **Direct column matches**: 0-1000 points

### Files Modified

**`src/utils/searchUtils.ts`** - Core search logic with priority scoring:
- `parseNuclideNotation()` - Parse notation like "In-49"
- `findElementsByName()` - Match element names to symbols
- `getMatchScore()` - Calculate match quality scores
- `filterDataBySearch()` - Enhanced filtering with metadata support

**`src/components/SortableTable.tsx`** - Search metadata support:
- Added `searchMetadata` prop for element info and daughter nuclide getter
- Passes metadata to `filterDataBySearch()`

**`src/pages/ShowElementData.tsx`** - Integration in Element Data page:
- Search works before pagination (not after)
- Element name and daughter nuclide searching in Decays tab
- Proper result prioritization

## Benefits

- ✅ **More intuitive**: Users don't need to know element symbols
- ✅ **Faster discovery**: Find isotopes by common names
- ✅ **Better UX**: Search daughter nuclides in decay chains
- ✅ **Smart ranking**: Most relevant results appear first
- ✅ **Consistent**: Same search behavior across all data tables

## Testing

### Manual Testing
- ✅ Search "Carbon" in Nuclides tab → shows all C isotopes
- ✅ Search "C-14" in Decays tab → shows C-14 parent decays first
- ✅ Search "Francium" in Decays tab → prioritizes parent Fr decays
- ✅ Fuzzy matching: "carb" matches "Carbon"

### Technical Validation
- ✅ Search applies before pagination (not after)
- ✅ Match scores correctly prioritize parent over daughter
- ✅ Case-insensitive matching works
- ✅ Handles edge cases (empty searches, no matches)

## Related

- Follow-up to #12 (Tabbed Element Data Interface)