### PR TITLE
Fix: CloudFront distribution ID and S3 URL for db.lenr.academy deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,7 +153,8 @@ jobs:
           echo "Local database version: $LOCAL_VERSION"
 
           # Fetch remote version directly from S3 (bypass CloudFront cache)
-          REMOTE_VERSION=$(curl -sf https://db.lenr.academy.s3.amazonaws.com/latest/parkhomov.db.meta.json | jq -r '.version' 2>/dev/null || echo "none")
+          # Note: Use path-style URL because bucket name contains dots
+          REMOTE_VERSION=$(curl -sf https://s3.amazonaws.com/db.lenr.academy/latest/parkhomov.db.meta.json | jq -r '.version' 2>/dev/null || echo "none")
           echo "Remote database version: $REMOTE_VERSION"
 
           # Compare versions
@@ -185,7 +186,7 @@ jobs:
         if: steps.check_version.outputs.db_changed == 'true'
         run: |
           echo "🔄 Invalidating CloudFront cache for db.lenr.academy..."
-          aws cloudfront create-invalidation --distribution-id E2U0YFSVME3PDG --paths "/*"
+          aws cloudfront create-invalidation --distribution-id E2HHYQ6QJH13V0 --paths "/*"
 
       - name: Add database update summary
         run: |


### PR DESCRIPTION
Fixes #46

## Summary

The database deployment workflow was failing due to incorrect CloudFront distribution ID and S3 URL format for the `db.lenr.academy` bucket. This PR corrects both issues to ensure successful database deployments.

## Problem

When deploying database updates to S3, the workflow encountered two issues:

1. **Wrong CloudFront Distribution ID**: The workflow was using `E2U0YFSVME3PDG` (which belongs to the main site) instead of `E2HHYQ6QJH13V0` (which belongs to `db.lenr.academy`)
2. **SSL Certificate Mismatch**: Using virtual-hosted style S3 URLs (`https://db.lenr.academy.s3.amazonaws.com/`) causes SSL certificate validation errors because the bucket name contains dots

## Solution

**Changes in `.github/workflows/deploy.yml`:**

- Fixed CloudFront distribution ID: `E2U0YFSVME3PDG` → `E2HHYQ6QJH13V0`
- Changed S3 URL format from virtual-hosted style to path style:
  - Before: `https://db.lenr.academy.s3.amazonaws.com/`
  - After: `https://s3.amazonaws.com/db.lenr.academy/`

## Technical Details

**Why Path-Style URLs?**

When an S3 bucket name contains dots (like `db.lenr.academy`), virtual-hosted style URLs cause SSL certificate validation failures because:
- The URL becomes `https://db.lenr.academy.s3.amazonaws.com`
- The SSL certificate is for `*.s3.amazonaws.com`
- The dots in the bucket name break the wildcard match

Path-style URLs avoid this by putting the bucket name in the path instead of the subdomain.

## Impact

- ✅ Database deployment workflow now succeeds
- ✅ CloudFront cache invalidation targets the correct distribution
- ✅ No SSL certificate errors during deployment

## Testing

- ✅ Verified CloudFront distribution ID matches `db.lenr.academy`
- ✅ Path-style S3 URL resolves correctly
- ✅ No SSL validation errors

## Related

- Follow-up to #8 (Migrate database storage from Git LFS to S3 with versioning)
- Affects: Database version update workflow