### PR TITLE
Fix: Eliminate multiple /privacy page views with dynamic analytics loading

### DIFF
--- a/src/components/PrivacyBanner.tsx
+++ b/src/components/PrivacyBanner.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { X } from 'lucide-react'
+import { loadUmamiScript } from '../utils/analytics'
 
 const ANALYTICS_CONSENT_KEY = 'lenr-analytics-consent'
 const EXIT_ANIMATION_MS = 250
@@ -49,11 +50,15 @@ export default function PrivacyBanner({ className = '' }: PrivacyBannerProps) {
     }
   }, [])
 
-  const handleAccept = () => {
+  const handleAccept = async () => {
     localStorage.setItem(ANALYTICS_CONSENT_KEY, 'accepted')
     setIsVisible(false)
-    // Reload to enable analytics
-    window.location.reload()
+    // Load analytics script dynamically (no page reload needed)
+    try {
+      await loadUmamiScript()
+    } catch (error) {
+      console.error('Failed to load analytics:', error)
+    }
   }
 
   const handleOptOut = () => {

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,51 @@
+/**
+ * Utility functions for managing analytics script loading
+ */
+
+const UMAMI_SCRIPT_SRC = 'https://cloud.umami.is/script.js'
+const UMAMI_WEBSITE_ID = '916d0566-989b-47e1-9882-b06de40a1c95'
+
+/**
+ * Dynamically loads the Umami analytics script.
+ * This allows enabling analytics without a page reload.
+ *
+ * @returns Promise that resolves when the script is loaded, or immediately if already loaded
+ */
+export function loadUmamiScript(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    // Check if script is already loaded
+    const existingScript = document.querySelector(`script[src="${UMAMI_SCRIPT_SRC}"]`)
+    if (existingScript) {
+      console.log('[Analytics] Umami script already loaded')
+      resolve()
+      return
+    }
+
+    console.log('[Analytics] Loading Umami script dynamically...')
+
+    // Create and inject the script
+    const script = document.createElement('script')
+    script.defer = true
+    script.src = UMAMI_SCRIPT_SRC
+    script.setAttribute('data-website-id', UMAMI_WEBSITE_ID)
+
+    script.onload = () => {
+      console.log('[Analytics] Umami script loaded successfully')
+      resolve()
+    }
+
+    script.onerror = (error) => {
+      console.error('[Analytics] Failed to load Umami script:', error)
+      reject(new Error('Failed to load analytics script'))
+    }
+
+    document.head.appendChild(script)
+  })
+}
+
+/**
+ * Check if Umami script is currently loaded
+ */
+export function isUmamiLoaded(): boolean {
+  return !!document.querySelector(`script[src="${UMAMI_SCRIPT_SRC}"]`)
+}


### PR DESCRIPTION
## Summary

Fixes #65 - Eliminates multiple `/privacy` page views being tracked in rapid succession (4 hits within 4-8 seconds) by replacing page reload with dynamic Umami script injection.

## Problem

When users accepted analytics consent, the page performed a hard reload via `window.location.reload()`, which caused browser cache/history interactions that triggered multiple tracking events for the same page.

## Solution

Replaced `window.location.reload()` with dynamic Umami script loading for analytics consent:
- Created `src/utils/analytics.ts` with `loadUmamiScript()` function
- Updated `PrivacyBanner.tsx` to inject script dynamically (no reload)
- Updated `PrivacyPreferences.tsx` to use dynamic loading for analytics only
- Error reporting still uses reload (Sentry requires app restart)

## Benefits

- ✅ **Cleaner analytics data** - Single page view per actual navigation
- ✅ **Better UX** - Seamless consent flow without page disruption
- ✅ **Preserved error reporting** - Reload behavior maintained for Sentry

## Changes

### New Files
- `src/utils/analytics.ts` - Dynamic Umami script injection utility

### Modified Files
- `src/components/PrivacyBanner.tsx` - Use dynamic loading instead of reload
- `src/pages/PrivacyPreferences.tsx` - Dynamic loading for analytics, clarified reload message
- `e2e/tests/privacy-preferences.spec.ts` - Updated tests for no-reload behavior

## Testing

- ✅ Build successful
- ✅ E2E tests updated and passing
- 🔍 Manual testing needed to verify analytics tracking behavior
- 🔍 Need to verify single page view in Umami dashboard after accepting consent

## Test Plan

1. Clear browser localStorage and IndexedDB
2. Visit localhost:5173
3. Accept analytics via banner
4. Verify no page reload occurs
5. Check DevTools Network tab for Umami script load
6. Navigate to /privacy page
7. Toggle analytics on/off
8. Verify no reload when changing analytics preference
9. Change error reporting preference
10. Verify reload button appears (error reporting only)