### PR TITLE
fix: override mdast-util-gfm-autolink-literal to support iOS 15 (#102)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lenr-academy",
-  "version": "0.1.0-alpha.17",
+  "version": "0.1.0-alpha.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lenr-academy",
-      "version": "0.1.0-alpha.17",
+      "version": "0.1.0-alpha.18",
       "hasInstallScript": true,
       "dependencies": {
         "@sentry/react": "^10.19.0",
@@ -7691,23 +7691,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdast-util-gfm-autolink-literal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
-      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "ccount": "^2.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-find-and-replace": "^3.0.0",
-        "micromark-util-character": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/mdast-util-gfm-footnote": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
@@ -7767,6 +7750,23 @@
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm/node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.0.tgz",
+      "integrity": "sha512-FyzMsduZZHSc3i0Px3PQcBT4WJY/X/RCtEJKuybiC6sjPqLv7h1yqAkmILZtuxMSsUyaLUWNp71+vQH2zqp5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -98,5 +98,8 @@
     "vite-plugin-pwa": "^1.1.0",
     "vitest": "^4.0.2",
     "workbox-window": "^7.3.0"
+  },
+  "overrides": {
+    "mdast-util-gfm-autolink-literal": "2.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Fixes #102 by adding an npm override to force `mdast-util-gfm-autolink-literal@2.0.0`, which is compatible with Safari < 16.4 (iOS < 16.4).

## Problem

Users on iOS 15 devices (Safari 15.6.3) are experiencing crashes with the error:
```
SyntaxError: Invalid regular expression: invalid group specifier name
```

This occurs when the ChangelogModal renders release notes containing GitHub-flavored markdown.

## Root Cause

The dependency `mdast-util-gfm-autolink-literal` version 2.0.1 uses regex lookbehind assertions `(?<=...)` which are not supported in Safari < 16.4. Specifically, the problematic regex pattern is:

```javascript
/(?<=^|\s|\p{P}|\p{S})([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/gu
```

Safari only added lookbehind support in version 16.4 (March 2023), leaving iOS 15 users unable to use the app.

## Solution

Added npm package override in `package.json` to force version 2.0.0 across the dependency tree:

```json
"overrides": {
  "mdast-util-gfm-autolink-literal": "2.0.0"
}
```

Version 2.0.0 does not use lookbehind assertions and is fully compatible with iOS 15.

## Changes

- **package.json**: Added `overrides` section to force compatible dependency version
- **package-lock.json**: Updated to reflect the override

## Testing

- ✅ Build successful (`npm run build`)
- ✅ All 176 unit tests passing (`npm run test:run`)
- ✅ Override verified: `npm ls mdast-util-gfm-autolink-literal` shows version 2.0.0

## Browser Support

This fix ensures compatibility with:
- Safari 15.6+ (iOS 15.7+)
- All modern browsers (Chrome, Firefox, Edge)

## References

- Issue: #102
- Related: https://github.com/syntax-tree/mdast-util-gfm-autolink-literal/issues/10
- Safari lookbehind support: https://bugs.webkit.org/show_bug.cgi?id=174931