### PR TITLE
feat(cascade): implement weighted fuel proportions and materials catalog

### DIFF
--- a/e2e/tests/weighted-cascade.spec.ts
+++ b/e2e/tests/weighted-cascade.spec.ts
@@ -1,0 +1,222 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Weighted Cascade (Issue #96)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to cascades page
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Cascades' }).click();
+    await expect(page).toHaveURL('/cascades');
+    // Wait for database to load
+    await expect(page.locator('button:has-text("Run Cascade Simulation")')).toBeEnabled({ timeout: 10000 });
+  });
+
+  test('should display weighted mode toggle', async ({ page }) => {
+    // Check for weighted mode toggle
+    const weightedToggle = page.getByTestId('weighted-mode-toggle');
+    await expect(weightedToggle).toBeVisible();
+
+    // Toggle should be unchecked by default
+    await expect(weightedToggle).not.toBeChecked();
+
+    // Should have label "Weighted Mode"
+    await expect(page.locator('text=Weighted Mode')).toBeVisible();
+  });
+
+  test('should display materials catalog button', async ({ page }) => {
+    // Check for materials button
+    const materialsButton = page.getByTestId('materials-catalog-button');
+    await expect(materialsButton).toBeVisible();
+    await expect(materialsButton).toContainText('Materials');
+  });
+
+  test('should open and close materials catalog modal', async ({ page }) => {
+    // Click materials button
+    const materialsButton = page.getByTestId('materials-catalog-button');
+    await materialsButton.click();
+
+    // Modal should open
+    await expect(page.locator('text=Materials Catalog')).toBeVisible();
+
+    // Should have category tabs
+    await expect(page.locator('button:has-text("All")')).toBeVisible();
+    await expect(page.locator('button:has-text("Natural")')).toBeVisible();
+    await expect(page.locator('button:has-text("Alloys")')).toBeVisible();
+
+    // Close modal with X button
+    await page.locator('button[aria-label="Close"]').click();
+
+    // Modal should close
+    await expect(page.locator('text=Materials Catalog')).not.toBeVisible();
+  });
+
+  test('should filter materials by category', async ({ page }) => {
+    // Open materials catalog
+    await page.getByTestId('materials-catalog-button').click();
+    await expect(page.locator('text=Materials Catalog')).toBeVisible();
+
+    // Click on Natural tab
+    await page.locator('button:has-text("Natural")').click();
+
+    // Should show natural abundance materials
+    await expect(page.locator('text=Natural Lithium')).toBeVisible();
+    await expect(page.locator('text=Natural Nickel')).toBeVisible();
+
+    // Click on Alloys tab
+    await page.locator('button:has-text("Alloys")').click();
+
+    // Should show alloy materials
+    await expect(page.locator('text=Stainless Steel 304')).toBeVisible();
+  });
+
+  test('should search materials', async ({ page }) => {
+    // Open materials catalog
+    await page.getByTestId('materials-catalog-button').click();
+    await expect(page.locator('text=Materials Catalog')).toBeVisible();
+
+    // Search for nickel
+    await page.locator('input[placeholder*="Search"]').fill('nickel');
+
+    // Should filter results
+    await expect(page.locator('text=Natural Nickel')).toBeVisible();
+    // Other non-matching materials should be filtered
+    await expect(page.locator('text=Natural Lithium')).not.toBeVisible();
+  });
+
+  test('should load material and enable weighted mode', async ({ page }) => {
+    // Open materials catalog
+    await page.getByTestId('materials-catalog-button').click();
+    await expect(page.locator('text=Materials Catalog')).toBeVisible();
+
+    // Click on Natural Lithium
+    await page.locator('text=Natural Lithium').click();
+
+    // Find the load button for this material and click it
+    const loadButton = page.locator('button:has-text("Load")').first();
+    await loadButton.click();
+
+    // Modal should close
+    await expect(page.locator('text=Materials Catalog')).not.toBeVisible();
+
+    // Weighted mode should be enabled
+    const weightedToggle = page.getByTestId('weighted-mode-toggle');
+    await expect(weightedToggle).toBeChecked();
+
+    // Proportion input should be visible (appears when weighted mode is on and nuclides selected)
+    await expect(page.locator('text=Fuel Proportions')).toBeVisible();
+  });
+
+  test('should show proportion input when weighted mode enabled', async ({ page }) => {
+    // Enable weighted mode
+    const weightedToggle = page.getByTestId('weighted-mode-toggle');
+    await weightedToggle.check();
+
+    // Should show proportion input
+    await expect(page.locator('text=Fuel Proportions')).toBeVisible();
+
+    // Should show equal distribution by default (since default nuclides are selected)
+    // The first nuclide should have a proportion display
+    await expect(page.getByTestId('fuel-proportion-input')).toBeVisible();
+  });
+
+  test('should show weighted mode info banner', async ({ page }) => {
+    // Enable weighted mode
+    const weightedToggle = page.getByTestId('weighted-mode-toggle');
+    await weightedToggle.check();
+
+    // Should show weighted mode info
+    await expect(page.locator('text=Weighted Mode:')).toBeVisible();
+    await expect(page.locator('text=Pathway frequencies will be weighted')).toBeVisible();
+  });
+
+  test('should disable weighted mode toggle', async ({ page }) => {
+    // Enable weighted mode
+    const weightedToggle = page.getByTestId('weighted-mode-toggle');
+    await weightedToggle.check();
+    await expect(weightedToggle).toBeChecked();
+
+    // Proportion input should be visible
+    await expect(page.locator('text=Fuel Proportions')).toBeVisible();
+
+    // Disable weighted mode
+    await weightedToggle.uncheck();
+    await expect(weightedToggle).not.toBeChecked();
+
+    // Proportion input should be hidden
+    await expect(page.locator('text=Fuel Proportions')).not.toBeVisible();
+  });
+
+  test('should run cascade with weighted mode and display results', async ({ page }) => {
+    // Enable weighted mode
+    const weightedToggle = page.getByTestId('weighted-mode-toggle');
+    await weightedToggle.check();
+
+    // Set low loop count for speed
+    const loopInput = page.locator('label:has-text("Max Cascade Loops")').locator('..').locator('input[type="range"]');
+    await loopInput.fill('3');
+
+    // Run simulation
+    const runButton = page.locator('button:has-text("Run Cascade Simulation")');
+    await runButton.click();
+
+    // Wait for results
+    await expect(page.locator('text=Cascade Complete')).toBeVisible({ timeout: 30000 });
+
+    // Results should display
+    await expect(page.locator('text=Reactions Found')).toBeVisible();
+  });
+
+  test('should reset weighted mode on parameter reset', async ({ page }) => {
+    // Enable weighted mode
+    const weightedToggle = page.getByTestId('weighted-mode-toggle');
+    await weightedToggle.check();
+    await expect(weightedToggle).toBeChecked();
+
+    // Reset parameters
+    await page.click('button:has-text("Reset Parameters")');
+
+    // Weighted mode should be disabled
+    await expect(weightedToggle).not.toBeChecked();
+  });
+});
+
+test.describe('Materials Catalog Categories', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/cascades');
+    await expect(page.locator('button:has-text("Run Cascade Simulation")')).toBeEnabled({ timeout: 10000 });
+    // Open materials catalog
+    await page.getByTestId('materials-catalog-button').click();
+    await expect(page.locator('text=Materials Catalog')).toBeVisible();
+  });
+
+  test('should display LENR experiments', async ({ page }) => {
+    // Click on LENR tab
+    await page.locator('button:has-text("LENR")').click();
+
+    // Should show LENR experiment materials
+    await expect(page.locator('text=Parkhomov')).toBeVisible();
+    await expect(page.locator('text=Piantelli')).toBeVisible();
+  });
+
+  test('should display compounds', async ({ page }) => {
+    // Click on Compounds tab
+    await page.locator('button:has-text("Compounds")').click();
+
+    // Should show compound materials
+    await expect(page.locator('text=LiAlH4')).toBeVisible();
+    await expect(page.locator('text=NaBH4')).toBeVisible();
+  });
+
+  test('should show material composition preview', async ({ page }) => {
+    // Click on Natural tab
+    await page.locator('button:has-text("Natural")').click();
+
+    // Click on Natural Lithium
+    await page.locator('text=Natural Lithium').click();
+
+    // Should show composition details
+    await expect(page.locator('text=Li-6')).toBeVisible();
+    await expect(page.locator('text=Li-7')).toBeVisible();
+    // Should show isotopic proportions
+    await expect(page.locator('text=%')).toBeVisible();
+  });
+});

--- a/e2e/tests/weighted-cascade.spec.ts
+++ b/e2e/tests/weighted-cascade.spec.ts
@@ -3,17 +3,15 @@ import { test, expect } from '@playwright/test';
 test.describe('Weighted Cascade (Issue #96)', () => {
   test.beforeEach(async ({ page }) => {
     // Navigate to cascades page
-    await page.goto('/');
-    await page.getByRole('link', { name: 'Cascades' }).click();
-    await expect(page).toHaveURL('/cascades');
-    // Wait for database to load
-    await expect(page.locator('button:has-text("Run Cascade Simulation")')).toBeEnabled({ timeout: 10000 });
+    await page.goto('/cascades');
+    // Wait for database to load (may take longer on first load)
+    await expect(page.locator('button:has-text("Run Cascade Simulation")')).toBeEnabled({ timeout: 30000 });
   });
 
   test('should display weighted mode toggle', async ({ page }) => {
-    // Check for weighted mode toggle
+    // Check for weighted mode toggle (sr-only checkbox inside label)
     const weightedToggle = page.getByTestId('weighted-mode-toggle');
-    await expect(weightedToggle).toBeVisible();
+    await expect(weightedToggle).toBeAttached();
 
     // Toggle should be unchecked by default
     await expect(weightedToggle).not.toBeChecked();
@@ -35,93 +33,103 @@ test.describe('Weighted Cascade (Issue #96)', () => {
     await materialsButton.click();
 
     // Modal should open
-    await expect(page.locator('text=Materials Catalog')).toBeVisible();
+    const modal = page.getByTestId('materials-catalog-modal');
+    await expect(modal).toBeVisible();
 
-    // Should have category tabs
-    await expect(page.locator('button:has-text("All")')).toBeVisible();
-    await expect(page.locator('button:has-text("Natural")')).toBeVisible();
-    await expect(page.locator('button:has-text("Alloys")')).toBeVisible();
+    // Should have Materials Catalog heading
+    await expect(modal.locator('h2')).toContainText('Materials Catalog');
 
-    // Close modal with X button
-    await page.locator('button[aria-label="Close"]').click();
+    // Should have materials list (use button selector for specificity)
+    await expect(modal.locator('button:has-text("Natural Lithium")')).toBeVisible();
+
+    // Close modal using Cancel button within modal
+    await modal.locator('button:has-text("Cancel")').click();
 
     // Modal should close
-    await expect(page.locator('text=Materials Catalog')).not.toBeVisible();
+    await expect(modal).not.toBeVisible();
   });
 
   test('should filter materials by category', async ({ page }) => {
     // Open materials catalog
     await page.getByTestId('materials-catalog-button').click();
-    await expect(page.locator('text=Materials Catalog')).toBeVisible();
+    await expect(page.locator('h2:has-text("Materials Catalog")')).toBeVisible();
 
-    // Click on Natural tab
-    await page.locator('button:has-text("Natural")').click();
+    // Click on Natural tab (first button with "Natural" is the tab, not material cards)
+    await page.locator('button:has-text("Natural")').first().click();
 
     // Should show natural abundance materials
-    await expect(page.locator('text=Natural Lithium')).toBeVisible();
-    await expect(page.locator('text=Natural Nickel')).toBeVisible();
+    await expect(page.locator('button:has-text("Natural Lithium")')).toBeVisible();
+    await expect(page.locator('button:has-text("Natural Nickel")')).toBeVisible();
 
-    // Click on Alloys tab
-    await page.locator('button:has-text("Alloys")').click();
+    // Click on Alloys tab (first button with "Alloys" is the tab)
+    await page.locator('button:has-text("Alloys")').first().click();
 
     // Should show alloy materials
-    await expect(page.locator('text=Stainless Steel 304')).toBeVisible();
+    await expect(page.locator('button:has-text("Stainless Steel 304")')).toBeVisible();
   });
 
   test('should search materials', async ({ page }) => {
     // Open materials catalog
+    const modal = page.getByTestId('materials-catalog-modal');
     await page.getByTestId('materials-catalog-button').click();
-    await expect(page.locator('text=Materials Catalog')).toBeVisible();
+    await expect(modal).toBeVisible();
 
     // Search for nickel
-    await page.locator('input[placeholder*="Search"]').fill('nickel');
+    await modal.locator('input[placeholder*="Search"]').fill('nickel');
 
-    // Should filter results
-    await expect(page.locator('text=Natural Nickel')).toBeVisible();
+    // Should filter results - use button selector for material cards
+    await expect(modal.locator('button:has-text("Natural Nickel")')).toBeVisible();
     // Other non-matching materials should be filtered
-    await expect(page.locator('text=Natural Lithium')).not.toBeVisible();
+    await expect(modal.locator('button:has-text("Natural Lithium")')).not.toBeVisible();
   });
 
   test('should load material and enable weighted mode', async ({ page }) => {
     // Open materials catalog
+    const modal = page.getByTestId('materials-catalog-modal');
     await page.getByTestId('materials-catalog-button').click();
-    await expect(page.locator('text=Materials Catalog')).toBeVisible();
+    await expect(modal).toBeVisible();
 
-    // Click on Natural Lithium
-    await page.locator('text=Natural Lithium').click();
+    // Click on Natural tab (first button matching "Natural" is the tab, not material cards)
+    await modal.locator('button:has-text("Natural")').first().click();
 
-    // Find the load button for this material and click it
-    const loadButton = page.locator('button:has-text("Load")').first();
+    // Click on Natural Lithium material card to select it
+    await modal.locator('button:has-text("Natural Lithium")').click();
+
+    // Wait for Load Material button to become enabled after selection
+    const loadButton = modal.locator('button:has-text("Load Material")');
+    await expect(loadButton).toBeEnabled();
     await loadButton.click();
 
     // Modal should close
-    await expect(page.locator('text=Materials Catalog')).not.toBeVisible();
+    await expect(modal).not.toBeVisible();
 
     // Weighted mode should be enabled
     const weightedToggle = page.getByTestId('weighted-mode-toggle');
     await expect(weightedToggle).toBeChecked();
 
-    // Proportion input should be visible (appears when weighted mode is on and nuclides selected)
-    await expect(page.locator('text=Fuel Proportions')).toBeVisible();
-  });
-
-  test('should show proportion input when weighted mode enabled', async ({ page }) => {
-    // Enable weighted mode
-    const weightedToggle = page.getByTestId('weighted-mode-toggle');
-    await weightedToggle.check();
-
-    // Should show proportion input
-    await expect(page.locator('text=Fuel Proportions')).toBeVisible();
-
-    // Should show equal distribution by default (since default nuclides are selected)
-    // The first nuclide should have a proportion display
+    // Proportion input should be visible (use testId for specificity)
     await expect(page.getByTestId('fuel-proportion-input')).toBeVisible();
   });
 
-  test('should show weighted mode info banner', async ({ page }) => {
-    // Enable weighted mode
+  test('should show proportion input when weighted mode enabled', async ({ page }) => {
+    // Enable weighted mode by clicking the label (checkbox is sr-only)
+    await page.locator('label:has-text("Weighted Mode")').click();
+
+    // Verify it's checked
     const weightedToggle = page.getByTestId('weighted-mode-toggle');
-    await weightedToggle.check();
+    await expect(weightedToggle).toBeChecked();
+
+    // Should show proportion input (use testId for specificity)
+    const proportionInput = page.getByTestId('fuel-proportion-input');
+    await expect(proportionInput).toBeVisible();
+
+    // Should have the Fuel Proportions label within the component
+    await expect(proportionInput.locator('text=Fuel Proportions')).toBeVisible();
+  });
+
+  test('should show weighted mode info banner', async ({ page }) => {
+    // Enable weighted mode by clicking the label (checkbox is sr-only)
+    await page.locator('label:has-text("Weighted Mode")').click();
 
     // Should show weighted mode info
     await expect(page.locator('text=Weighted Mode:')).toBeVisible();
@@ -129,26 +137,28 @@ test.describe('Weighted Cascade (Issue #96)', () => {
   });
 
   test('should disable weighted mode toggle', async ({ page }) => {
-    // Enable weighted mode
+    // Enable weighted mode by clicking the label (checkbox is sr-only)
+    const weightedToggleLabel = page.locator('label:has-text("Weighted Mode")');
+    await weightedToggleLabel.click();
+
     const weightedToggle = page.getByTestId('weighted-mode-toggle');
-    await weightedToggle.check();
     await expect(weightedToggle).toBeChecked();
 
-    // Proportion input should be visible
-    await expect(page.locator('text=Fuel Proportions')).toBeVisible();
+    // Proportion input should be visible (use testId)
+    const proportionInput = page.getByTestId('fuel-proportion-input');
+    await expect(proportionInput).toBeVisible();
 
-    // Disable weighted mode
-    await weightedToggle.uncheck();
+    // Disable weighted mode by clicking the label again
+    await weightedToggleLabel.click();
     await expect(weightedToggle).not.toBeChecked();
 
     // Proportion input should be hidden
-    await expect(page.locator('text=Fuel Proportions')).not.toBeVisible();
+    await expect(proportionInput).not.toBeVisible();
   });
 
   test('should run cascade with weighted mode and display results', async ({ page }) => {
-    // Enable weighted mode
-    const weightedToggle = page.getByTestId('weighted-mode-toggle');
-    await weightedToggle.check();
+    // Enable weighted mode by clicking the label (checkbox is sr-only)
+    await page.locator('label:has-text("Weighted Mode")').click();
 
     // Set low loop count for speed
     const loopInput = page.locator('label:has-text("Max Cascade Loops")').locator('..').locator('input[type="range"]');
@@ -166,9 +176,10 @@ test.describe('Weighted Cascade (Issue #96)', () => {
   });
 
   test('should reset weighted mode on parameter reset', async ({ page }) => {
-    // Enable weighted mode
+    // Enable weighted mode by clicking the label (checkbox is sr-only)
+    await page.locator('label:has-text("Weighted Mode")').click();
+
     const weightedToggle = page.getByTestId('weighted-mode-toggle');
-    await weightedToggle.check();
     await expect(weightedToggle).toBeChecked();
 
     // Reset parameters
@@ -182,41 +193,43 @@ test.describe('Weighted Cascade (Issue #96)', () => {
 test.describe('Materials Catalog Categories', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/cascades');
-    await expect(page.locator('button:has-text("Run Cascade Simulation")')).toBeEnabled({ timeout: 10000 });
+    await expect(page.locator('button:has-text("Run Cascade Simulation")')).toBeEnabled({ timeout: 30000 });
     // Open materials catalog
     await page.getByTestId('materials-catalog-button').click();
-    await expect(page.locator('text=Materials Catalog')).toBeVisible();
+    await expect(page.getByTestId('materials-catalog-modal')).toBeVisible();
   });
 
   test('should display LENR experiments', async ({ page }) => {
-    // Click on LENR tab
-    await page.locator('button:has-text("LENR")').click();
+    // Click on LENR tab (first button with "LENR" is the tab)
+    await page.locator('button:has-text("LENR")').first().click();
 
-    // Should show LENR experiment materials
-    await expect(page.locator('text=Parkhomov')).toBeVisible();
-    await expect(page.locator('text=Piantelli')).toBeVisible();
+    // Wait for tab content to update and show LENR experiment materials
+    await expect(page.locator('button:has-text("Parkhomov")')).toBeVisible();
+    await expect(page.locator('button:has-text("Piantelli")')).toBeVisible();
   });
 
   test('should display compounds', async ({ page }) => {
-    // Click on Compounds tab
-    await page.locator('button:has-text("Compounds")').click();
+    // Click on Compounds tab (first button with "Compounds" is the tab)
+    await page.locator('button:has-text("Compounds")').first().click();
 
-    // Should show compound materials
-    await expect(page.locator('text=LiAlH4')).toBeVisible();
-    await expect(page.locator('text=NaBH4')).toBeVisible();
+    // Should show compound materials (these are button cards)
+    await expect(page.locator('button:has-text("LiAlH4")')).toBeVisible();
+    await expect(page.locator('button:has-text("NaBH4")')).toBeVisible();
   });
 
   test('should show material composition preview', async ({ page }) => {
-    // Click on Natural tab
-    await page.locator('button:has-text("Natural")').click();
+    const modal = page.getByTestId('materials-catalog-modal');
 
-    // Click on Natural Lithium
-    await page.locator('text=Natural Lithium').click();
+    // Click on Natural tab (first button with "Natural" is the tab)
+    await modal.locator('button:has-text("Natural")').first().click();
 
-    // Should show composition details
-    await expect(page.locator('text=Li-6')).toBeVisible();
-    await expect(page.locator('text=Li-7')).toBeVisible();
-    // Should show isotopic proportions
-    await expect(page.locator('text=%')).toBeVisible();
+    // Click on Natural Lithium material card to select it and show preview
+    await modal.locator('button:has-text("Natural Lithium")').click();
+
+    // Should show composition details in the preview panel (use table cells for specificity)
+    await expect(modal.getByRole('cell', { name: 'Li-6' })).toBeVisible();
+    await expect(modal.getByRole('cell', { name: 'Li-7' })).toBeVisible();
+    // Should show isotopic proportions (at least one percentage cell visible)
+    await expect(modal.getByRole('cell', { name: /%/ }).first()).toBeVisible();
   });
 });

--- a/src/components/CascadeSankeyDiagram.tsx
+++ b/src/components/CascadeSankeyDiagram.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react';
 import { Sankey, Tooltip, ResponsiveContainer, Rectangle } from 'recharts';
-import { Sliders, HelpCircle, X } from 'lucide-react';
+import { Sliders, HelpCircle, X, Scale } from 'lucide-react';
 import type { PathwayAnalysis } from '../services/pathwayAnalyzer';
+import type { WeightedPathwayAnalysis } from '../types';
 import { SankeyErrorBoundary } from './SankeyErrorBoundary';
 
 interface CascadeSankeyDiagramProps {
-  pathways: PathwayAnalysis[];
+  pathways: PathwayAnalysis[] | WeightedPathwayAnalysis[];
   fuelNuclides?: string[];  // Original fuel nuclides for color coding
+  useWeightedMode?: boolean; // Whether weighted data is available (Issue #96)
 }
 
 type NodeType = 'fuel' | 'intermediate' | 'final';
@@ -40,10 +42,25 @@ function parseNuclide(nuclideId: string): { element: string; Z: number; A: numbe
 }
 
 /**
+ * Helper to get frequency value (weighted or regular)
+ */
+function getFrequencyValue(pathway: PathwayAnalysis | WeightedPathwayAnalysis, useWeighted: boolean): number {
+  if (useWeighted && 'weightedFrequency' in pathway) {
+    return pathway.weightedFrequency;
+  }
+  return pathway.frequency;
+}
+
+/**
  * Convert pathways to Sankey data format with color coding
  * Recharts Sankey expects node indices (numbers) for source/target
+ * Supports weighted frequency when available (Issue #96)
  */
-function pathwaysToSankeyData(pathways: PathwayAnalysis[], fuelNuclides: string[] = []) {
+function pathwaysToSankeyData(
+  pathways: PathwayAnalysis[] | WeightedPathwayAnalysis[],
+  fuelNuclides: string[] = [],
+  useWeighted: boolean = false
+) {
   const nodeMap = new Map<string, number>();
   const nodes: EnhancedNode[] = [];
   const links: Array<{ source: number; target: number; value: number; pathway: PathwayAnalysis }> = [];
@@ -64,7 +81,7 @@ function pathwaysToSankeyData(pathways: PathwayAnalysis[], fuelNuclides: string[
   // Track which nodes have outgoing edges (to identify final products)
   const hasOutgoingEdges = new Set<string>();
   pathways.forEach((pathway) => {
-    pathway.inputs.forEach((input) => hasOutgoingEdges.add(input));
+    pathway.inputs.forEach((input: string) => hasOutgoingEdges.add(input));
   });
 
   // Sort pathways to minimize crossings in Sankey diagram
@@ -155,7 +172,9 @@ function pathwaysToSankeyData(pathways: PathwayAnalysis[], fuelNuclides: string[
     // For two-to-two reactions (A + B → C + D), we create all possible links
     const numInputs = pathway.inputs.length;
     const numOutputs = pathway.outputs.length;
-    const valuePerLink = pathway.frequency / Math.max(numInputs, numOutputs);
+    // Use weighted frequency when available (Issue #96)
+    const freqValue = getFrequencyValue(pathway, useWeighted);
+    const valuePerLink = freqValue / Math.max(numInputs, numOutputs);
 
     // Create links from each input to corresponding outputs
     for (let i = 0; i < Math.max(numInputs, numOutputs); i++) {
@@ -187,13 +206,14 @@ function pathwaysToSankeyData(pathways: PathwayAnalysis[], fuelNuclides: string[
   });
 
   // Convert aggregated links to array
-  // Use the most frequent pathway for tooltip display
-  linkMap.forEach(({ source, target, value, pathways }) => {
+  // Use the most frequent pathway for tooltip display (considers weighted frequency)
+  linkMap.forEach(({ source, target, value, pathways: linkPathways }) => {
     links.push({
       source,
       target,
       value,
-      pathway: pathways.sort((a, b) => b.frequency - a.frequency)[0], // Show most frequent pathway in tooltip
+      // Show most frequent (or weighted) pathway in tooltip
+      pathway: linkPathways.sort((a, b) => getFrequencyValue(b, useWeighted) - getFrequencyValue(a, useWeighted))[0],
     });
   });
 
@@ -209,17 +229,22 @@ function pathwaysToSankeyData(pathways: PathwayAnalysis[], fuelNuclides: string[
  * Shows flow of cascade reactions from fuel nuclides through intermediates to products.
  * Width of flows represents pathway frequency.
  */
-export default function CascadeSankeyDiagram({ pathways, fuelNuclides = [] }: CascadeSankeyDiagramProps) {
+export default function CascadeSankeyDiagram({ pathways, fuelNuclides = [], useWeightedMode = false }: CascadeSankeyDiagramProps) {
   const [topN, setTopN] = useState(15);
   const [feedbackOnly, setFeedbackOnly] = useState(false);
   const [minFrequency, setMinFrequency] = useState(1);
   const [showFilters, setShowFilters] = useState(false);
   const [renderError, setRenderError] = useState<string | null>(null);
+  // Toggle for weighted vs raw view when weighted data is available (Issue #96)
+  const [showWeightedView, setShowWeightedView] = useState(useWeightedMode);
   const [showGuide, setShowGuide] = useState(() => {
     // Show guide on first visit
     const hasSeenGuide = localStorage.getItem('cascade-sankey-guide-seen');
     return !hasSeenGuide;
   });
+
+  // Determine if weighted data is actually available
+  const hasWeightedData = pathways.length > 0 && 'weightedFrequency' in pathways[0];
 
   // Safety: Clamp topN to max of 30 to prevent stack overflow
   // Note: Even 30 pathways can create 60+ nodes and links which strains Recharts
@@ -249,17 +274,20 @@ export default function CascadeSankeyDiagram({ pathways, fuelNuclides = [] }: Ca
   }
 
   // Sort by frequency (descending) to ensure "Top N" shows the most frequent
-  filteredPathways.sort((a, b) => b.frequency - a.frequency);
+  // Use weighted frequency when in weighted view mode (Issue #96)
+  const useWeighted = showWeightedView && hasWeightedData;
+  filteredPathways.sort((a, b) => getFrequencyValue(b, useWeighted) - getFrequencyValue(a, useWeighted));
 
   // Limit to top N (using safe clamped value)
   const beforeTopNLimit = filteredPathways.length;
   filteredPathways = filteredPathways.slice(0, safeTopN);
 
   // Convert to Sankey format with color coding
+  // Pass weighted mode flag for flow width calculation (Issue #96)
   let sankeyData;
   let nodeCountExceeded = false;
   try {
-    sankeyData = pathwaysToSankeyData(filteredPathways, fuelNuclides);
+    sankeyData = pathwaysToSankeyData(filteredPathways, fuelNuclides, useWeighted);
 
     // Additional safety check: limit total node count to prevent stack overflow
     // Recharts Sankey can overflow with >50 nodes even with good pathway limits
@@ -273,7 +301,7 @@ export default function CascadeSankeyDiagram({ pathways, fuelNuclides = [] }: Ca
 
       while (attempts < 5 && sankeyData.nodes.length > MAX_NODES && reducedPathways > 5) {
         const testPathways = filteredPathways.slice(0, reducedPathways);
-        sankeyData = pathwaysToSankeyData(testPathways, fuelNuclides);
+        sankeyData = pathwaysToSankeyData(testPathways, fuelNuclides, useWeighted);
 
         if (sankeyData.nodes.length <= MAX_NODES) {
           filteredPathways = testPathways;
@@ -334,9 +362,14 @@ export default function CascadeSankeyDiagram({ pathways, fuelNuclides = [] }: Ca
       Z
     `;
 
-    const pathway = linkData.pathway as PathwayAnalysis;
+    const pathway = linkData.pathway as PathwayAnalysis | WeightedPathwayAnalysis;
+    // Build tooltip with weighted info if available (Issue #96)
+    let freqText = `Frequency: ×${pathway.frequency}`;
+    if (useWeighted && 'weightedFrequency' in pathway) {
+      freqText = `Weighted: ×${pathway.weightedFrequency.toFixed(2)} (raw: ×${pathway.frequency})`;
+    }
     const tooltipText = pathway ?
-      `${pathway.pathway}\nType: ${pathway.type === 'fusion' ? 'Fusion' : 'Two-to-Two'}\nFrequency: ×${pathway.frequency}\nAvg Energy: ${pathway.avgEnergy.toFixed(2)} MeV${pathway.isFeedback ? '\n✓ Feedback Loop' : ''}`
+      `${pathway.pathway}\nType: ${pathway.type === 'fusion' ? 'Fusion' : 'Two-to-Two'}\n${freqText}\nAvg Energy: ${pathway.avgEnergy.toFixed(2)} MeV${pathway.isFeedback ? '\n✓ Feedback Loop' : ''}`
       : '';
 
     return (
@@ -363,14 +396,15 @@ export default function CascadeSankeyDiagram({ pathways, fuelNuclides = [] }: Ca
     );
   };
 
-  // Custom tooltip
+  // Custom tooltip with weighted frequency support (Issue #96)
   const CustomTooltip = ({ active, payload }: any) => {
     if (!active || !payload || !payload.length) return null;
 
     const data = payload[0].payload;
     if (!data.pathway) return null;
 
-    const pathway = data.pathway as PathwayAnalysis;
+    const pathway = data.pathway as PathwayAnalysis | WeightedPathwayAnalysis;
+    const isWeighted = useWeighted && 'weightedFrequency' in pathway;
 
     return (
       <div className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg p-3 shadow-lg">
@@ -382,9 +416,21 @@ export default function CascadeSankeyDiagram({ pathways, fuelNuclides = [] }: Ca
               {pathway.type === 'fusion' ? 'Fusion' : 'Two-to-Two'}
             </span>
           </p>
-          <p>
-            <span className="font-medium">Frequency:</span> ×{pathway.frequency}
-          </p>
+          {isWeighted ? (
+            <>
+              <p>
+                <span className="font-medium">Weighted Frequency:</span>{' '}
+                <span className="text-purple-600">×{(pathway as WeightedPathwayAnalysis).weightedFrequency.toFixed(2)}</span>
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Raw frequency: ×{pathway.frequency}
+              </p>
+            </>
+          ) : (
+            <p>
+              <span className="font-medium">Frequency:</span> ×{pathway.frequency}
+            </p>
+          )}
           <p>
             <span className="font-medium">Avg Energy:</span> {pathway.avgEnergy.toFixed(2)} MeV
           </p>
@@ -482,13 +528,30 @@ export default function CascadeSankeyDiagram({ pathways, fuelNuclides = [] }: Ca
             </button>
           )}
         </div>
-        <button
-          onClick={() => setShowFilters(!showFilters)}
-          className="flex items-center gap-2 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        >
-          <Sliders className="w-4 h-4" />
-          {showFilters ? 'Hide' : 'Show'} Filters
-        </button>
+        <div className="flex items-center gap-3">
+          {/* Weighted view toggle (Issue #96) */}
+          {hasWeightedData && (
+            <button
+              onClick={() => setShowWeightedView(!showWeightedView)}
+              className={`flex items-center gap-1.5 px-3 py-2 text-sm rounded-lg transition-colors ${
+                showWeightedView
+                  ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300'
+                  : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
+              }`}
+              title={showWeightedView ? 'Switch to raw frequencies' : 'Switch to weighted frequencies'}
+            >
+              <Scale className="w-4 h-4" />
+              {showWeightedView ? 'Weighted' : 'Raw'}
+            </button>
+          )}
+          <button
+            onClick={() => setShowFilters(!showFilters)}
+            className="flex items-center gap-2 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+          >
+            <Sliders className="w-4 h-4" />
+            {showFilters ? 'Hide' : 'Show'} Filters
+          </button>
+        </div>
       </div>
 
       {/* Filter Controls */}
@@ -567,7 +630,13 @@ export default function CascadeSankeyDiagram({ pathways, fuelNuclides = [] }: Ca
         <p>
           Showing <strong>{filteredPathways.length}</strong> of <strong>{totalPathways}</strong> total pathways
           {beforeTopNLimit > safeTopN && (
-            <span className="text-gray-500"> (top {safeTopN} by frequency)</span>
+            <span className="text-gray-500"> (top {safeTopN} by {useWeighted ? 'weighted ' : ''}frequency)</span>
+          )}
+          {useWeighted && (
+            <span className="ml-2 text-purple-600 dark:text-purple-400 font-medium">
+              <Scale className="w-3 h-3 inline mr-0.5" />
+              Weighted view
+            </span>
           )}
         </p>
         {(minFrequency > 1 || feedbackOnly) && (
@@ -725,8 +794,11 @@ export default function CascadeSankeyDiagram({ pathways, fuelNuclides = [] }: Ca
           </div>
         </div>
         <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700 text-xs text-gray-600 dark:text-gray-400 space-y-1">
-          <p>💡 <strong>Flow width</strong> represents how often each reaction pathway occurs</p>
+          <p>💡 <strong>Flow width</strong> represents {useWeighted ? 'weighted frequency (fuel proportions applied)' : 'how often each reaction pathway occurs'}</p>
           <p>💡 <strong>Hover</strong> over flows to see detailed reaction information</p>
+          {hasWeightedData && (
+            <p>💡 Use the <strong>{showWeightedView ? 'Weighted' : 'Raw'}</strong> button to toggle between weighted and raw frequencies</p>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/MaterialsCatalog.tsx
+++ b/src/components/MaterialsCatalog.tsx
@@ -1,0 +1,483 @@
+import { useState, useMemo } from 'react';
+import { X, Search, Beaker, Factory, FlaskConical, Atom, Save, Trash2, ChevronRight, User } from 'lucide-react';
+import type { Material, MaterialCategory, WeightedNuclide } from '../types';
+import {
+  getAllMaterials,
+  searchMaterials,
+  materialToWeightedNuclides,
+  saveCustomMaterial,
+  deleteCustomMaterial,
+  createMaterialFromWeightedNuclides,
+  getCustomMaterials,
+} from '../services/materialsService';
+import { formatProportion } from '../services/proportionService';
+
+interface MaterialsCatalogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectMaterial: (weightedNuclides: WeightedNuclide[]) => void;
+  currentFuel?: WeightedNuclide[];
+}
+
+type TabKey = 'all' | 'natural-abundance' | 'alloy' | 'compound' | 'lenr-experiment' | 'custom';
+
+const TABS: { key: TabKey; label: string; icon: typeof Atom }[] = [
+  { key: 'all', label: 'All', icon: Beaker },
+  { key: 'natural-abundance', label: 'Natural', icon: Atom },
+  { key: 'alloy', label: 'Alloys', icon: Factory },
+  { key: 'compound', label: 'Compounds', icon: FlaskConical },
+  { key: 'lenr-experiment', label: 'LENR', icon: Beaker },
+  { key: 'custom', label: 'Custom', icon: User },
+];
+
+/**
+ * Materials Catalog Modal
+ *
+ * Allows users to browse and select materials from the catalog,
+ * or save their current fuel mixture as a custom material.
+ */
+export default function MaterialsCatalog({
+  isOpen,
+  onClose,
+  onSelectMaterial,
+  currentFuel,
+}: MaterialsCatalogProps) {
+  const [activeTab, setActiveTab] = useState<TabKey>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedMaterial, setSelectedMaterial] = useState<Material | null>(null);
+  const [showSaveDialog, setShowSaveDialog] = useState(false);
+  const [saveName, setSaveName] = useState('');
+  const [saveDescription, setSaveDescription] = useState('');
+
+  // Filter materials based on tab and search
+  const filteredMaterials = useMemo(() => {
+    let materials = searchQuery.trim()
+      ? searchMaterials(searchQuery)
+      : getAllMaterials();
+
+    if (activeTab !== 'all') {
+      materials = materials.filter((m) => m.category === activeTab);
+    }
+
+    return materials;
+  }, [activeTab, searchQuery]);
+
+  // Get icon for category
+  const getCategoryIcon = (category: MaterialCategory) => {
+    switch (category) {
+      case 'natural-abundance':
+        return <Atom className="w-4 h-4" />;
+      case 'alloy':
+        return <Factory className="w-4 h-4" />;
+      case 'compound':
+        return <FlaskConical className="w-4 h-4" />;
+      case 'lenr-experiment':
+        return <Beaker className="w-4 h-4" />;
+      case 'custom':
+        return <User className="w-4 h-4" />;
+    }
+  };
+
+  // Get color for category
+  const getCategoryColor = (category: MaterialCategory) => {
+    switch (category) {
+      case 'natural-abundance':
+        return 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-300';
+      case 'alloy':
+        return 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300';
+      case 'compound':
+        return 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300';
+      case 'lenr-experiment':
+        return 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300';
+      case 'custom':
+        return 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300';
+    }
+  };
+
+  // Handle material selection
+  const handleSelect = () => {
+    if (!selectedMaterial) return;
+    const weightedNuclides = materialToWeightedNuclides(selectedMaterial);
+    onSelectMaterial(weightedNuclides);
+    onClose();
+  };
+
+  // Handle save custom material
+  const handleSaveCustom = () => {
+    if (!currentFuel || currentFuel.length === 0 || !saveName.trim()) return;
+
+    const materialData = createMaterialFromWeightedNuclides(
+      currentFuel,
+      saveName.trim(),
+      saveDescription.trim() || `Custom fuel mixture saved on ${new Date().toLocaleDateString()}`
+    );
+
+    saveCustomMaterial(materialData);
+    setShowSaveDialog(false);
+    setSaveName('');
+    setSaveDescription('');
+    // Refresh to show new material
+    setActiveTab('custom');
+  };
+
+  // Handle delete custom material
+  const handleDeleteCustom = (id: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (confirm('Delete this custom material?')) {
+      deleteCustomMaterial(id);
+      if (selectedMaterial?.id === id) {
+        setSelectedMaterial(null);
+      }
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Modal Overlay */}
+      <div
+        data-testid="materials-catalog-overlay"
+        className="fixed inset-0 bg-black/60 z-[100] flex items-center justify-center p-4"
+        onClick={onClose}
+      >
+        {/* Modal Content */}
+        <div
+          data-testid="materials-catalog-modal"
+          className="bg-white dark:bg-gray-800 rounded-lg shadow-2xl max-w-4xl w-full max-h-[90vh] overflow-hidden flex flex-col"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
+            <div>
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+                Materials Catalog
+              </h2>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                Select a material or save your current fuel mixture
+              </p>
+            </div>
+            <button
+              onClick={onClose}
+              className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+
+          {/* Search and Actions */}
+          <div className="p-4 bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700">
+            <div className="flex gap-3">
+              <div className="relative flex-1">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                <input
+                  type="text"
+                  placeholder="Search materials..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="w-full pl-10 pr-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  data-testid="materials-search-input"
+                />
+              </div>
+              {currentFuel && currentFuel.length > 0 && (
+                <button
+                  onClick={() => setShowSaveDialog(true)}
+                  className="flex items-center gap-2 px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-lg transition-colors"
+                  data-testid="save-custom-material-button"
+                >
+                  <Save className="w-4 h-4" />
+                  Save Current
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* Tabs */}
+          <div className="flex border-b border-gray-200 dark:border-gray-700 overflow-x-auto">
+            {TABS.map((tab) => {
+              const Icon = tab.icon;
+              const count = tab.key === 'all'
+                ? getAllMaterials().length
+                : tab.key === 'custom'
+                  ? getCustomMaterials().length
+                  : getAllMaterials().filter((m) => m.category === tab.key).length;
+
+              return (
+                <button
+                  key={tab.key}
+                  onClick={() => setActiveTab(tab.key)}
+                  className={`
+                    flex items-center gap-2 px-4 py-3 text-sm font-medium whitespace-nowrap border-b-2 transition-colors
+                    ${activeTab === tab.key
+                      ? 'border-primary-600 text-primary-600 dark:text-primary-400'
+                      : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:border-gray-300 dark:hover:border-gray-600'
+                    }
+                  `}
+                  data-testid={`materials-tab-${tab.key}`}
+                >
+                  <Icon className="w-4 h-4" />
+                  {tab.label}
+                  <span className="text-xs bg-gray-200 dark:bg-gray-700 px-1.5 py-0.5 rounded-full">
+                    {count}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Content Area */}
+          <div className="flex flex-1 overflow-hidden">
+            {/* Materials List */}
+            <div className="w-1/2 border-r border-gray-200 dark:border-gray-700 overflow-y-auto">
+              {filteredMaterials.length === 0 ? (
+                <div className="p-8 text-center text-gray-500 dark:text-gray-400">
+                  {searchQuery
+                    ? `No materials found for "${searchQuery}"`
+                    : 'No materials in this category'}
+                </div>
+              ) : (
+                <div className="divide-y divide-gray-200 dark:divide-gray-700">
+                  {filteredMaterials.map((material) => (
+                    <button
+                      key={material.id}
+                      onClick={() => setSelectedMaterial(material)}
+                      className={`
+                        w-full p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors
+                        ${selectedMaterial?.id === material.id
+                          ? 'bg-primary-50 dark:bg-primary-900/20 border-l-4 border-primary-500'
+                          : ''
+                        }
+                      `}
+                      data-testid={`material-item-${material.id}`}
+                    >
+                      <div className="flex items-start justify-between">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2">
+                            <span className={`p-1 rounded ${getCategoryColor(material.category)}`}>
+                              {getCategoryIcon(material.category)}
+                            </span>
+                            <span className="font-medium text-gray-900 dark:text-white">
+                              {material.name}
+                            </span>
+                          </div>
+                          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 line-clamp-2">
+                            {material.description}
+                          </p>
+                          <div className="flex gap-1 mt-2">
+                            {material.tags?.slice(0, 3).map((tag) => (
+                              <span
+                                key={tag}
+                                className="text-xs px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded"
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          {material.isCustom && (
+                            <button
+                              onClick={(e) => handleDeleteCustom(material.id, e)}
+                              className="p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded"
+                              title="Delete custom material"
+                            >
+                              <Trash2 className="w-4 h-4" />
+                            </button>
+                          )}
+                          <ChevronRight className="w-5 h-5 text-gray-400" />
+                        </div>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Material Details */}
+            <div className="w-1/2 overflow-y-auto p-4">
+              {selectedMaterial ? (
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+                    {selectedMaterial.name}
+                  </h3>
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                    {selectedMaterial.description}
+                  </p>
+
+                  {/* Source citation */}
+                  {selectedMaterial.source && (
+                    <div className="mb-4">
+                      <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                        Source:
+                      </span>
+                      <p className="text-sm text-gray-700 dark:text-gray-300 mt-1">
+                        {selectedMaterial.source}
+                      </p>
+                    </div>
+                  )}
+
+                  {/* LENR experiment details */}
+                  {'researcher' in selectedMaterial && (
+                    <div className="mb-4 p-3 bg-purple-50 dark:bg-purple-900/20 rounded-lg">
+                      <div className="text-sm">
+                        <div className="flex justify-between">
+                          <span className="text-gray-600 dark:text-gray-400">Researcher:</span>
+                          <span className="font-medium text-gray-900 dark:text-white">
+                            {(selectedMaterial as any).researcher}
+                          </span>
+                        </div>
+                        {(selectedMaterial as any).year && (
+                          <div className="flex justify-between mt-1">
+                            <span className="text-gray-600 dark:text-gray-400">Year:</span>
+                            <span className="font-medium text-gray-900 dark:text-white">
+                              {(selectedMaterial as any).year}
+                            </span>
+                          </div>
+                        )}
+                        {(selectedMaterial as any).experimentType && (
+                          <div className="flex justify-between mt-1">
+                            <span className="text-gray-600 dark:text-gray-400">Type:</span>
+                            <span className="font-medium text-gray-900 dark:text-white">
+                              {(selectedMaterial as any).experimentType}
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Composition table */}
+                  <div className="mb-4">
+                    <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      Composition ({selectedMaterial.composition.length} nuclides)
+                    </h4>
+                    <div className="max-h-48 overflow-y-auto border border-gray-200 dark:border-gray-700 rounded-lg">
+                      <table className="w-full text-sm">
+                        <thead className="bg-gray-50 dark:bg-gray-900/50 sticky top-0">
+                          <tr>
+                            <th className="text-left px-3 py-2 text-gray-600 dark:text-gray-400">
+                              Nuclide
+                            </th>
+                            <th className="text-right px-3 py-2 text-gray-600 dark:text-gray-400">
+                              Proportion
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                          {selectedMaterial.composition.map((comp) => (
+                            <tr key={comp.nuclideId}>
+                              <td className="px-3 py-2 font-mono text-gray-900 dark:text-white">
+                                {comp.nuclideId}
+                              </td>
+                              <td className="px-3 py-2 text-right text-gray-600 dark:text-gray-400">
+                                {formatProportion(comp.proportion)}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="h-full flex items-center justify-center text-gray-500 dark:text-gray-400">
+                  <div className="text-center">
+                    <Beaker className="w-12 h-12 mx-auto mb-3 opacity-50" />
+                    <p>Select a material to view details</p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Footer Actions */}
+          <div className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-900/50 border-t border-gray-200 dark:border-gray-700">
+            <div className="text-sm text-gray-600 dark:text-gray-400">
+              {filteredMaterials.length} materials available
+            </div>
+            <div className="flex gap-2">
+              <button
+                onClick={onClose}
+                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSelect}
+                disabled={!selectedMaterial}
+                className="px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:bg-gray-400 disabled:cursor-not-allowed rounded-lg transition-colors"
+                data-testid="load-material-button"
+              >
+                Load Material
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Save Custom Material Dialog */}
+      {showSaveDialog && (
+        <div
+          className="fixed inset-0 bg-black/60 z-[110] flex items-center justify-center p-4"
+          onClick={() => setShowSaveDialog(false)}
+        >
+          <div
+            className="bg-white dark:bg-gray-800 rounded-lg shadow-2xl max-w-md w-full p-6"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+              Save Custom Material
+            </h3>
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Name *
+                </label>
+                <input
+                  type="text"
+                  value={saveName}
+                  onChange={(e) => setSaveName(e.target.value)}
+                  placeholder="My Custom Fuel Mix"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                  data-testid="save-material-name-input"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Description
+                </label>
+                <textarea
+                  value={saveDescription}
+                  onChange={(e) => setSaveDescription(e.target.value)}
+                  placeholder="Optional description..."
+                  rows={3}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white resize-none"
+                />
+              </div>
+              <div className="text-sm text-gray-600 dark:text-gray-400">
+                This will save your current fuel mixture ({currentFuel?.length || 0} nuclides)
+                as a custom material.
+              </div>
+            </div>
+            <div className="flex justify-end gap-2 mt-6">
+              <button
+                onClick={() => setShowSaveDialog(false)}
+                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSaveCustom}
+                disabled={!saveName.trim()}
+                className="px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:bg-gray-400 disabled:cursor-not-allowed rounded-lg transition-colors"
+                data-testid="confirm-save-material-button"
+              >
+                Save Material
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/MaterialsCatalog.tsx
+++ b/src/components/MaterialsCatalog.tsx
@@ -198,6 +198,7 @@ export default function MaterialsCatalog({
             </div>
             <button
               onClick={onClose}
+              aria-label="Close"
               className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
             >
               <X className="w-5 h-5" />

--- a/src/components/MaterialsCatalog.tsx
+++ b/src/components/MaterialsCatalog.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from 'react';
-import { X, Search, Beaker, Factory, FlaskConical, Atom, Save, Trash2, ChevronRight, User } from 'lucide-react';
+import { X, Search, Beaker, Factory, FlaskConical, Atom, Save, Trash2, ChevronRight, User, Plus, Layers } from 'lucide-react';
 import type { Material, MaterialCategory, WeightedNuclide } from '../types';
 import {
   getAllMaterials,
@@ -10,7 +10,7 @@ import {
   createMaterialFromWeightedNuclides,
   getCustomMaterials,
 } from '../services/materialsService';
-import { formatProportion } from '../services/proportionService';
+import { formatProportion, mergeWeightedNuclides } from '../services/proportionService';
 
 interface MaterialsCatalogProps {
   isOpen: boolean;
@@ -48,6 +48,10 @@ export default function MaterialsCatalog({
   const [showSaveDialog, setShowSaveDialog] = useState(false);
   const [saveName, setSaveName] = useState('');
   const [saveDescription, setSaveDescription] = useState('');
+
+  // Blend mode state
+  const [blendMode, setBlendMode] = useState(false);
+  const [blendMaterials, setBlendMaterials] = useState<Material[]>([]);
 
   // Filter materials based on tab and search
   const filteredMaterials = useMemo(() => {
@@ -94,12 +98,47 @@ export default function MaterialsCatalog({
     }
   };
 
-  // Handle material selection
+  // Handle material selection (single replace mode)
   const handleSelect = () => {
     if (!selectedMaterial) return;
     const weightedNuclides = materialToWeightedNuclides(selectedMaterial);
     onSelectMaterial(weightedNuclides);
     onClose();
+  };
+
+  // Add material to blend queue
+  const handleAddToBlend = () => {
+    if (!selectedMaterial) return;
+    // Don't add duplicates
+    if (blendMaterials.some((m) => m.id === selectedMaterial.id)) return;
+    setBlendMaterials([...blendMaterials, selectedMaterial]);
+    setSelectedMaterial(null);
+  };
+
+  // Remove material from blend queue
+  const handleRemoveFromBlend = (materialId: string) => {
+    setBlendMaterials(blendMaterials.filter((m) => m.id !== materialId));
+  };
+
+  // Clear all materials from blend queue
+  const handleClearBlend = () => {
+    setBlendMaterials([]);
+    setSelectedMaterial(null);
+  };
+
+  // Apply blended materials
+  const handleApplyBlend = () => {
+    if (blendMaterials.length === 0) return;
+    const allNuclides = blendMaterials.map((m) => materialToWeightedNuclides(m));
+    const blended = mergeWeightedNuclides(...allNuclides);
+    onSelectMaterial(blended);
+    setBlendMaterials([]);
+    onClose();
+  };
+
+  // Check if material is in blend queue
+  const isInBlend = (materialId: string) => {
+    return blendMaterials.some((m) => m.id === materialId);
   };
 
   // Handle save custom material
@@ -167,7 +206,7 @@ export default function MaterialsCatalog({
 
           {/* Search and Actions */}
           <div className="p-4 bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700">
-            <div className="flex gap-3">
+            <div className="flex gap-3 mb-3">
               <div className="relative flex-1">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
                 <input
@@ -190,10 +229,80 @@ export default function MaterialsCatalog({
                 </button>
               )}
             </div>
+
+            {/* Mode Toggle */}
+            <div className="flex items-center gap-4">
+              <span className="text-sm text-gray-600 dark:text-gray-400">Mode:</span>
+              <div className="flex rounded-lg border border-gray-300 dark:border-gray-600 overflow-hidden">
+                <button
+                  onClick={() => setBlendMode(false)}
+                  className={`px-3 py-1.5 text-sm font-medium transition-colors ${
+                    !blendMode
+                      ? 'bg-primary-600 text-white'
+                      : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                  }`}
+                  data-testid="mode-replace"
+                >
+                  Replace
+                </button>
+                <button
+                  onClick={() => setBlendMode(true)}
+                  className={`px-3 py-1.5 text-sm font-medium transition-colors flex items-center gap-1.5 ${
+                    blendMode
+                      ? 'bg-primary-600 text-white'
+                      : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                  }`}
+                  data-testid="mode-blend"
+                >
+                  <Layers className="w-3.5 h-3.5" />
+                  Blend
+                </button>
+              </div>
+              {blendMode && blendMaterials.length > 0 && (
+                <span className="text-sm text-primary-600 dark:text-primary-400 font-medium">
+                  {blendMaterials.length} selected
+                </span>
+              )}
+            </div>
+
+            {/* Blend Queue */}
+            {blendMode && blendMaterials.length > 0 && (
+              <div className="mt-3 p-3 bg-primary-50 dark:bg-primary-900/20 rounded-lg border border-primary-200 dark:border-primary-800">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm font-medium text-primary-700 dark:text-primary-300">
+                    Materials to blend:
+                  </span>
+                  <button
+                    onClick={handleClearBlend}
+                    className="text-xs text-primary-600 dark:text-primary-400 hover:underline"
+                    data-testid="clear-blend-button"
+                  >
+                    Clear all
+                  </button>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {blendMaterials.map((material) => (
+                    <span
+                      key={material.id}
+                      className="inline-flex items-center gap-1 px-2 py-1 bg-white dark:bg-gray-800 rounded text-sm text-gray-700 dark:text-gray-300 border border-primary-200 dark:border-primary-700"
+                    >
+                      {material.name}
+                      <button
+                        onClick={() => handleRemoveFromBlend(material.id)}
+                        className="text-gray-400 hover:text-red-500 ml-1"
+                        title="Remove from blend"
+                      >
+                        <X className="w-3.5 h-3.5" />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Tabs */}
-          <div className="flex border-b border-gray-200 dark:border-gray-700 overflow-x-auto">
+          <div className="flex flex-wrap border-b border-gray-200 dark:border-gray-700">
             {TABS.map((tab) => {
               const Icon = tab.icon;
               const count = tab.key === 'all'
@@ -237,58 +346,68 @@ export default function MaterialsCatalog({
                 </div>
               ) : (
                 <div className="divide-y divide-gray-200 dark:divide-gray-700">
-                  {filteredMaterials.map((material) => (
-                    <button
-                      key={material.id}
-                      onClick={() => setSelectedMaterial(material)}
-                      className={`
-                        w-full p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors
-                        ${selectedMaterial?.id === material.id
-                          ? 'bg-primary-50 dark:bg-primary-900/20 border-l-4 border-primary-500'
-                          : ''
-                        }
-                      `}
-                      data-testid={`material-item-${material.id}`}
-                    >
-                      <div className="flex items-start justify-between">
-                        <div className="flex-1">
-                          <div className="flex items-center gap-2">
-                            <span className={`p-1 rounded ${getCategoryColor(material.category)}`}>
-                              {getCategoryIcon(material.category)}
-                            </span>
-                            <span className="font-medium text-gray-900 dark:text-white">
-                              {material.name}
-                            </span>
-                          </div>
-                          <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 line-clamp-2">
-                            {material.description}
-                          </p>
-                          <div className="flex gap-1 mt-2">
-                            {material.tags?.slice(0, 3).map((tag) => (
-                              <span
-                                key={tag}
-                                className="text-xs px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded"
-                              >
-                                {tag}
+                  {filteredMaterials.map((material) => {
+                    const inBlend = isInBlend(material.id);
+                    return (
+                      <button
+                        key={material.id}
+                        onClick={() => setSelectedMaterial(material)}
+                        className={`
+                          w-full p-4 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors
+                          ${selectedMaterial?.id === material.id
+                            ? 'bg-primary-50 dark:bg-primary-900/20 border-l-4 border-primary-500'
+                            : inBlend
+                              ? 'bg-green-50 dark:bg-green-900/20 border-l-4 border-green-500'
+                              : ''
+                          }
+                        `}
+                        data-testid={`material-item-${material.id}`}
+                      >
+                        <div className="flex items-start justify-between">
+                          <div className="flex-1">
+                            <div className="flex items-center gap-2">
+                              <span className={`p-1 rounded ${getCategoryColor(material.category)}`}>
+                                {getCategoryIcon(material.category)}
                               </span>
-                            ))}
+                              <span className="font-medium text-gray-900 dark:text-white">
+                                {material.name}
+                              </span>
+                              {inBlend && (
+                                <span className="text-xs px-1.5 py-0.5 bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-300 rounded">
+                                  In blend
+                                </span>
+                              )}
+                            </div>
+                            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1 line-clamp-2">
+                              {material.description}
+                            </p>
+                            <div className="flex gap-1 mt-2">
+                              {material.tags?.slice(0, 3).map((tag) => (
+                                <span
+                                  key={tag}
+                                  className="text-xs px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 rounded"
+                                >
+                                  {tag}
+                                </span>
+                              ))}
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            {material.isCustom && (
+                              <button
+                                onClick={(e) => handleDeleteCustom(material.id, e)}
+                                className="p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded"
+                                title="Delete custom material"
+                              >
+                                <Trash2 className="w-4 h-4" />
+                              </button>
+                            )}
+                            <ChevronRight className="w-5 h-5 text-gray-400" />
                           </div>
                         </div>
-                        <div className="flex items-center gap-2">
-                          {material.isCustom && (
-                            <button
-                              onClick={(e) => handleDeleteCustom(material.id, e)}
-                              className="p-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded"
-                              title="Delete custom material"
-                            >
-                              <Trash2 className="w-4 h-4" />
-                            </button>
-                          )}
-                          <ChevronRight className="w-5 h-5 text-gray-400" />
-                        </div>
-                      </div>
-                    </button>
-                  ))}
+                      </button>
+                    );
+                  })}
                 </div>
               )}
             </div>
@@ -351,9 +470,9 @@ export default function MaterialsCatalog({
                     <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                       Composition ({selectedMaterial.composition.length} nuclides)
                     </h4>
-                    <div className="max-h-48 overflow-y-auto border border-gray-200 dark:border-gray-700 rounded-lg">
+                    <div className="max-h-80 overflow-y-auto overscroll-contain border border-gray-200 dark:border-gray-700 rounded-lg">
                       <table className="w-full text-sm">
-                        <thead className="bg-gray-50 dark:bg-gray-900/50 sticky top-0">
+                        <thead className="bg-gray-50 dark:bg-gray-800 sticky top-0">
                           <tr>
                             <th className="text-left px-3 py-2 text-gray-600 dark:text-gray-400">
                               Nuclide
@@ -402,14 +521,37 @@ export default function MaterialsCatalog({
               >
                 Cancel
               </button>
-              <button
-                onClick={handleSelect}
-                disabled={!selectedMaterial}
-                className="px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:bg-gray-400 disabled:cursor-not-allowed rounded-lg transition-colors"
-                data-testid="load-material-button"
-              >
-                Load Material
-              </button>
+              {blendMode ? (
+                <>
+                  <button
+                    onClick={handleAddToBlend}
+                    disabled={!selectedMaterial || isInBlend(selectedMaterial?.id || '')}
+                    className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-green-600 hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed rounded-lg transition-colors"
+                    data-testid="add-to-blend-button"
+                  >
+                    <Plus className="w-4 h-4" />
+                    Add to Blend
+                  </button>
+                  <button
+                    onClick={handleApplyBlend}
+                    disabled={blendMaterials.length === 0}
+                    className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:bg-gray-400 disabled:cursor-not-allowed rounded-lg transition-colors"
+                    data-testid="apply-blend-button"
+                  >
+                    <Layers className="w-4 h-4" />
+                    Apply Blend ({blendMaterials.length})
+                  </button>
+                </>
+              ) : (
+                <button
+                  onClick={handleSelect}
+                  disabled={!selectedMaterial}
+                  className="px-4 py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 disabled:bg-gray-400 disabled:cursor-not-allowed rounded-lg transition-colors"
+                  data-testid="load-material-button"
+                >
+                  Load Material
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/PathwayBrowserTable.tsx
+++ b/src/components/PathwayBrowserTable.tsx
@@ -1,14 +1,27 @@
 import { useState, useMemo } from 'react';
-import { Search, ArrowUpDown, Filter, ChevronUp, ChevronDown } from 'lucide-react';
+import { Search, ArrowUpDown, Filter, ChevronUp, ChevronDown, Scale } from 'lucide-react';
 import type { PathwayAnalysis } from '../services/pathwayAnalyzer';
+import type { WeightedPathwayAnalysis } from '../types';
 import { VirtualizedList } from './VirtualizedList';
 
 interface PathwayBrowserTableProps {
-  pathways: PathwayAnalysis[];
+  pathways: PathwayAnalysis[] | WeightedPathwayAnalysis[];
+  useWeightedMode?: boolean; // Whether weighted data is available (Issue #96)
 }
 
-type SortField = 'frequency' | 'avgEnergy' | 'totalEnergy' | 'rarity' | 'loops';
+// Sort fields include weighted frequency when available
+type SortField = 'frequency' | 'weightedFrequency' | 'avgEnergy' | 'totalEnergy' | 'rarity' | 'loops';
 type SortDirection = 'asc' | 'desc';
+
+/**
+ * Helper to get frequency value (weighted or regular)
+ */
+function getFrequencyValue(pathway: PathwayAnalysis | WeightedPathwayAnalysis, useWeighted: boolean): number {
+  if (useWeighted && 'weightedFrequency' in pathway) {
+    return pathway.weightedFrequency;
+  }
+  return pathway.frequency;
+}
 
 /**
  * Format loop array for display
@@ -40,7 +53,7 @@ function formatLoops(loops: number[]): string {
  * Sortable, filterable table for exploring cascade pathways.
  * Enables pattern discovery through ranking and filtering.
  */
-export default function PathwayBrowserTable({ pathways }: PathwayBrowserTableProps) {
+export default function PathwayBrowserTable({ pathways, useWeightedMode = false }: PathwayBrowserTableProps) {
   const [sortField, setSortField] = useState<SortField>('frequency');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [searchTerm, setSearchTerm] = useState('');
@@ -49,6 +62,12 @@ export default function PathwayBrowserTable({ pathways }: PathwayBrowserTablePro
   const [feedbackOnly, setFeedbackOnly] = useState(false);
   const [minFrequency, setMinFrequency] = useState(1);
   const [showFilters, setShowFilters] = useState(false);
+  // Toggle for weighted view when weighted data is available (Issue #96)
+  const [showWeightedView, setShowWeightedView] = useState(useWeightedMode);
+
+  // Determine if weighted data is actually available
+  const hasWeightedData = pathways.length > 0 && 'weightedFrequency' in pathways[0];
+  const useWeighted = showWeightedView && hasWeightedData;
 
   // Filter and sort pathways
   const filteredAndSorted = useMemo(() => {
@@ -88,6 +107,10 @@ export default function PathwayBrowserTable({ pathways }: PathwayBrowserTablePro
         case 'frequency':
           comparison = a.frequency - b.frequency;
           break;
+        case 'weightedFrequency':
+          // Sort by weighted frequency when available (Issue #96)
+          comparison = getFrequencyValue(a, true) - getFrequencyValue(b, true);
+          break;
         case 'avgEnergy':
           comparison = a.avgEnergy - b.avgEnergy;
           break;
@@ -109,7 +132,7 @@ export default function PathwayBrowserTable({ pathways }: PathwayBrowserTablePro
     });
 
     return result;
-  }, [pathways, sortField, sortDirection, searchTerm, showFusion, showTwoToTwo, feedbackOnly, minFrequency]);
+  }, [pathways, sortField, sortDirection, searchTerm, showFusion, showTwoToTwo, feedbackOnly, minFrequency, useWeighted]);
 
   const handleSort = (field: SortField) => {
     if (sortField === field) {
@@ -233,10 +256,33 @@ export default function PathwayBrowserTable({ pathways }: PathwayBrowserTablePro
         </div>
       </div>
 
-      {/* Results Count */}
-      <p className="text-sm text-gray-600 dark:text-gray-400">
-        Showing {filteredAndSorted.length} of {pathways.length} pathways
-      </p>
+      {/* Results Count and Weighted Toggle */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          Showing {filteredAndSorted.length} of {pathways.length} pathways
+          {useWeighted && (
+            <span className="ml-2 text-purple-600 dark:text-purple-400 font-medium">
+              <Scale className="w-3 h-3 inline mr-0.5" />
+              Weighted view
+            </span>
+          )}
+        </p>
+        {/* Weighted view toggle (Issue #96) */}
+        {hasWeightedData && (
+          <button
+            onClick={() => setShowWeightedView(!showWeightedView)}
+            className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg transition-colors ${
+              showWeightedView
+                ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300'
+                : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
+            }`}
+            title={showWeightedView ? 'Switch to raw frequencies' : 'Switch to weighted frequencies'}
+          >
+            <Scale className="w-4 h-4" />
+            {showWeightedView ? 'Weighted' : 'Raw'}
+          </button>
+        )}
+      </div>
 
       {/* Table with Virtualization */}
       <div className="rounded-lg border border-gray-300 dark:border-gray-700 overflow-hidden">
@@ -245,11 +291,19 @@ export default function PathwayBrowserTable({ pathways }: PathwayBrowserTablePro
           <table className="w-full text-sm" style={{ tableLayout: 'fixed' }}>
             <thead className="bg-gray-50 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-b border-gray-300 dark:border-gray-700">
               <tr>
-                <th className="hidden md:table-cell px-4 py-3 text-left font-medium" style={{ width: '30%' }}>Pathway</th>
+                <th className="hidden md:table-cell px-4 py-3 text-left font-medium" style={{ width: useWeighted ? '25%' : '30%' }}>Pathway</th>
                 <th className="px-4 py-3 text-left font-medium" style={{ width: '10%' }}>Type</th>
                 <th className="px-4 py-3 text-right font-medium" style={{ width: '10%' }}>
                   <SortButton field="frequency">Count</SortButton>
                 </th>
+                {/* Weighted frequency column (Issue #96) */}
+                {useWeighted && (
+                  <th className="px-4 py-3 text-right font-medium" style={{ width: '10%' }}>
+                    <SortButton field="weightedFrequency">
+                      <span className="text-purple-600 dark:text-purple-400">Wtd</span>
+                    </SortButton>
+                  </th>
+                )}
                 <th className="px-4 py-3 text-right font-medium" style={{ width: '12%' }}>
                   <SortButton field="avgEnergy">Avg (MeV)</SortButton>
                 </th>
@@ -288,7 +342,7 @@ export default function PathwayBrowserTable({ pathways }: PathwayBrowserTablePro
                   {/* Data row */}
                   <tr className="text-gray-900 dark:text-gray-100">
                     {/* Desktop: Pathway in first column */}
-                    <td className="hidden md:table-cell px-4 py-2 font-mono text-sm align-middle" style={{ width: '30%' }}>
+                    <td className="hidden md:table-cell px-4 py-2 font-mono text-sm align-middle" style={{ width: useWeighted ? '25%' : '30%' }}>
                       {pathway.pathway}
                     </td>
 
@@ -304,6 +358,12 @@ export default function PathwayBrowserTable({ pathways }: PathwayBrowserTablePro
                       </span>
                     </td>
                     <td className="px-4 py-2 align-middle text-right font-medium" style={{ width: '10%' }}>×{pathway.frequency}</td>
+                    {/* Weighted frequency column (Issue #96) */}
+                    {useWeighted && (
+                      <td className="px-4 py-2 align-middle text-right font-medium text-purple-600 dark:text-purple-400" style={{ width: '10%' }}>
+                        ×{getFrequencyValue(pathway, true).toFixed(2)}
+                      </td>
+                    )}
                     <td className="px-4 py-2 align-middle text-right" style={{ width: '12%' }}>{pathway.avgEnergy.toFixed(2)}</td>
                     <td className="px-4 py-2 align-middle text-right" style={{ width: '12%' }}>{pathway.totalEnergy.toFixed(2)}</td>
                     <td className="hidden sm:table-cell px-4 py-2 align-middle text-center text-xs text-gray-600 dark:text-gray-400" style={{ width: '10%' }}>

--- a/src/components/ProportionInput.tsx
+++ b/src/components/ProportionInput.tsx
@@ -61,17 +61,33 @@ export default function ProportionInput({
   const [inputValues, setInputValues] = useState<Map<string, string>>(new Map());
   const [showTooltip, setShowTooltip] = useState(false);
 
+  // Format proportion for display in input field
+  // Uses reasonable precision: 2 decimals for values >= 1, 3 for < 1, 4 for < 0.1
+  const formatForInput = (value: number): string => {
+    if (value >= 1) {
+      return value.toFixed(2);
+    } else if (value >= 0.1) {
+      return value.toFixed(3);
+    } else if (value >= 0.001) {
+      return value.toFixed(4);
+    } else if (value === 0) {
+      return '0';
+    } else {
+      return value.toExponential(2);
+    }
+  };
+
   // Sync input values with weighted nuclides
   useEffect(() => {
     const newValues = new Map<string, string>();
     for (const nuclide of weightedNuclides) {
-      newValues.set(nuclide.nuclideId, nuclide.proportion.toString());
+      newValues.set(nuclide.nuclideId, formatForInput(nuclide.proportion));
     }
     // Add any new nuclides that aren't in weighted list
     for (const id of nuclideIds) {
       if (!newValues.has(id)) {
         // Default to equal distribution
-        newValues.set(id, (100 / nuclideIds.length).toFixed(2));
+        newValues.set(id, formatForInput(100 / nuclideIds.length));
       }
     }
     setInputValues(newValues);
@@ -307,7 +323,7 @@ export default function ProportionInput({
               </div>
 
               {/* Normalized percentage */}
-              <div className="w-16 text-right text-sm text-gray-500 dark:text-gray-400 font-mono">
+              <div className="w-20 text-right text-sm text-gray-500 dark:text-gray-400 font-mono">
                 {formatProportion(proportion)}
               </div>
             </div>

--- a/src/components/ProportionInput.tsx
+++ b/src/components/ProportionInput.tsx
@@ -1,0 +1,354 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Scale, RefreshCw, Percent, AlertCircle, Info } from 'lucide-react';
+import type { Database } from 'sql.js';
+import type { WeightedNuclide, ProportionFormat } from '../types';
+import {
+  validateProportions,
+  normalizeProportions,
+  getNaturalAbundances,
+  createEqualProportions,
+  formatProportion,
+  getFormatLabel,
+  getFormatHelpText,
+  type ProportionInput as ProportionInputType,
+  type ValidationResult,
+} from '../services/proportionService';
+import { parseNuclideNotation } from '../services/isotopeService';
+
+interface ProportionInputProps {
+  /** Selected nuclide IDs (e.g., ["Li-7", "Ni-58"]) */
+  nuclideIds: string[];
+  /** Current weighted nuclides */
+  weightedNuclides: WeightedNuclide[];
+  /** Callback when proportions change */
+  onProportionsChange: (nuclides: WeightedNuclide[]) => void;
+  /** Current format */
+  format: ProportionFormat;
+  /** Callback when format changes */
+  onFormatChange: (format: ProportionFormat) => void;
+  /** Database reference for natural abundance lookup */
+  db: Database | null;
+  /** Whether to auto-normalize on blur */
+  autoNormalize?: boolean;
+  /** Show format selector */
+  showFormatSelector?: boolean;
+  /** Label for the section */
+  label?: string;
+  /** Test ID prefix */
+  testId?: string;
+}
+
+/**
+ * ProportionInput Component
+ *
+ * Allows users to specify proportions for each fuel nuclide.
+ * Supports multiple input formats (percentage, atomic ratio, mass ratio)
+ * and includes quick actions for common operations.
+ */
+export default function ProportionInput({
+  nuclideIds,
+  weightedNuclides,
+  onProportionsChange,
+  format,
+  onFormatChange,
+  db,
+  autoNormalize = true,
+  showFormatSelector = true,
+  label = 'Fuel Proportions',
+  testId = 'proportion-input',
+}: ProportionInputProps) {
+  // Local input values (may not be normalized yet)
+  const [inputValues, setInputValues] = useState<Map<string, string>>(new Map());
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  // Sync input values with weighted nuclides
+  useEffect(() => {
+    const newValues = new Map<string, string>();
+    for (const nuclide of weightedNuclides) {
+      newValues.set(nuclide.nuclideId, nuclide.proportion.toString());
+    }
+    // Add any new nuclides that aren't in weighted list
+    for (const id of nuclideIds) {
+      if (!newValues.has(id)) {
+        // Default to equal distribution
+        newValues.set(id, (100 / nuclideIds.length).toFixed(2));
+      }
+    }
+    setInputValues(newValues);
+  }, [weightedNuclides, nuclideIds]);
+
+  // Build proportion inputs for validation
+  const proportionInputs = useMemo((): ProportionInputType[] => {
+    return nuclideIds.map((id) => ({
+      nuclideId: id,
+      value: parseFloat(inputValues.get(id) || '0') || 0,
+    }));
+  }, [nuclideIds, inputValues]);
+
+  // Validate current inputs
+  const validation = useMemo((): ValidationResult => {
+    return validateProportions(proportionInputs, format);
+  }, [proportionInputs, format]);
+
+  // Calculate total for display
+  const total = useMemo(() => {
+    return proportionInputs.reduce((sum, p) => sum + p.value, 0);
+  }, [proportionInputs]);
+
+  // Handle individual input change
+  const handleInputChange = (nuclideId: string, value: string) => {
+    const newValues = new Map(inputValues);
+    newValues.set(nuclideId, value);
+    setInputValues(newValues);
+  };
+
+  // Handle blur - optionally normalize
+  const handleInputBlur = () => {
+    if (autoNormalize && validation.isValid) {
+      const normalized = normalizeProportions(proportionInputs, 'manual');
+      onProportionsChange(normalized);
+    }
+  };
+
+  // Distribute equally
+  const handleDistributeEqually = () => {
+    const equal = createEqualProportions(nuclideIds, 'manual');
+    onProportionsChange(equal);
+  };
+
+  // Reset to natural abundances
+  const handleResetToNatural = () => {
+    if (!db) return;
+
+    // Group nuclides by element
+    const elementGroups = new Map<string, string[]>();
+    for (const id of nuclideIds) {
+      const parsed = parseNuclideNotation(id);
+      if (parsed) {
+        const existing = elementGroups.get(parsed.element) || [];
+        existing.push(id);
+        elementGroups.set(parsed.element, existing);
+      }
+    }
+
+    // Get natural abundances for each element and combine
+    const allWeighted: WeightedNuclide[] = [];
+    for (const [element, ids] of elementGroups) {
+      const natural = getNaturalAbundances(db, element);
+
+      // Scale by number of elements
+      const elementWeight = 100 / elementGroups.size;
+
+      // Find matching nuclides
+      for (const id of ids) {
+        const naturalMatch = natural.find((n) => n.nuclideId === id);
+        if (naturalMatch) {
+          allWeighted.push({
+            ...naturalMatch,
+            proportion: (naturalMatch.proportion * elementWeight) / 100,
+          });
+        }
+      }
+    }
+
+    // Normalize the combined result
+    const totalProportion = allWeighted.reduce((sum, n) => sum + n.proportion, 0);
+    if (totalProportion > 0) {
+      const normalized = allWeighted.map((n) => ({
+        ...n,
+        proportion: (n.proportion / totalProportion) * 100,
+      }));
+      onProportionsChange(normalized);
+    }
+  };
+
+  // Normalize current values
+  const handleNormalize = () => {
+    const normalized = normalizeProportions(proportionInputs, 'manual');
+    onProportionsChange(normalized);
+  };
+
+  if (nuclideIds.length === 0) {
+    return (
+      <div
+        data-testid={testId}
+        className="p-4 bg-gray-50 dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700"
+      >
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Select fuel nuclides to configure proportions
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid={testId}
+      className="space-y-4"
+    >
+      {/* Header with label and format selector */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Scale className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            {label}
+          </span>
+          <button
+            type="button"
+            className="relative"
+            onMouseEnter={() => setShowTooltip(true)}
+            onMouseLeave={() => setShowTooltip(false)}
+          >
+            <Info className="w-4 h-4 text-gray-400 dark:text-gray-500" />
+            {showTooltip && (
+              <div className="absolute left-0 top-6 z-50 w-64 p-2 text-xs text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700">
+                {getFormatHelpText(format)}
+              </div>
+            )}
+          </button>
+        </div>
+
+        {showFormatSelector && (
+          <select
+            value={format}
+            onChange={(e) => onFormatChange(e.target.value as ProportionFormat)}
+            className="text-sm px-2 py-1 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+            data-testid={`${testId}-format-selector`}
+          >
+            <option value="percentage">{getFormatLabel('percentage')}</option>
+            <option value="atomic-ratio">{getFormatLabel('atomic-ratio')}</option>
+            <option value="mass-ratio">{getFormatLabel('mass-ratio')}</option>
+          </select>
+        )}
+      </div>
+
+      {/* Quick Actions */}
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={handleDistributeEqually}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          data-testid={`${testId}-distribute-equally`}
+        >
+          <Scale className="w-3.5 h-3.5" />
+          Equal
+        </button>
+        <button
+          type="button"
+          onClick={handleResetToNatural}
+          disabled={!db}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          data-testid={`${testId}-natural-abundance`}
+        >
+          <RefreshCw className="w-3.5 h-3.5" />
+          Natural
+        </button>
+        <button
+          type="button"
+          onClick={handleNormalize}
+          disabled={total === 0}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          data-testid={`${testId}-normalize`}
+        >
+          <Percent className="w-3.5 h-3.5" />
+          Normalize
+        </button>
+      </div>
+
+      {/* Proportion Inputs */}
+      <div className="space-y-2">
+        {nuclideIds.map((nuclideId) => {
+          const value = inputValues.get(nuclideId) || '0';
+          const numValue = parseFloat(value) || 0;
+          const proportion = total > 0 ? (numValue / total) * 100 : 0;
+          const error = validation.errors.find((e) => e.nuclideId === nuclideId);
+
+          return (
+            <div key={nuclideId} className="flex items-center gap-3">
+              {/* Nuclide label */}
+              <div className="w-16 font-mono text-sm font-medium text-gray-700 dark:text-gray-300">
+                {nuclideId}
+              </div>
+
+              {/* Input field */}
+              <div className="relative flex-1">
+                <input
+                  type="number"
+                  value={value}
+                  onChange={(e) => handleInputChange(nuclideId, e.target.value)}
+                  onBlur={handleInputBlur}
+                  min="0"
+                  step={format === 'percentage' ? '0.1' : '1'}
+                  className={`
+                    w-full px-3 py-1.5 text-sm border rounded-lg
+                    bg-white dark:bg-gray-800
+                    text-gray-700 dark:text-gray-300
+                    ${error
+                      ? 'border-red-500 dark:border-red-400 focus:ring-red-500'
+                      : 'border-gray-300 dark:border-gray-600 focus:ring-primary-500'
+                    }
+                    focus:outline-none focus:ring-2 focus:ring-offset-0
+                  `}
+                  data-testid={`${testId}-input-${nuclideId}`}
+                />
+                {format === 'percentage' && (
+                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-400">
+                    %
+                  </span>
+                )}
+              </div>
+
+              {/* Proportion bar */}
+              <div className="w-24 h-4 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-primary-500 dark:bg-primary-400 transition-all duration-200"
+                  style={{ width: `${Math.min(100, proportion)}%` }}
+                />
+              </div>
+
+              {/* Normalized percentage */}
+              <div className="w-16 text-right text-sm text-gray-500 dark:text-gray-400 font-mono">
+                {formatProportion(proportion)}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Validation Errors */}
+      {!validation.isValid && (
+        <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+          <div className="flex items-start gap-2">
+            <AlertCircle className="w-4 h-4 text-red-500 dark:text-red-400 flex-shrink-0 mt-0.5" />
+            <div className="text-sm text-red-700 dark:text-red-300">
+              {validation.errors.map((error, idx) => (
+                <div key={idx}>{error.message}</div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Total display */}
+      <div className="flex items-center justify-between pt-2 border-t border-gray-200 dark:border-gray-700">
+        <span className="text-sm text-gray-600 dark:text-gray-400">
+          Total:
+        </span>
+        <span
+          className={`text-sm font-medium ${
+            Math.abs(total - 100) < 0.01
+              ? 'text-green-600 dark:text-green-400'
+              : 'text-yellow-600 dark:text-yellow-400'
+          }`}
+        >
+          {format === 'percentage' ? `${total.toFixed(2)}%` : total.toFixed(2)}
+          {format === 'percentage' && Math.abs(total - 100) >= 0.01 && (
+            <span className="text-xs text-gray-500 dark:text-gray-400 ml-1">
+              (will be normalized)
+            </span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/constants/materials.ts
+++ b/src/constants/materials.ts
@@ -1,0 +1,524 @@
+/**
+ * Materials Catalog Constants
+ *
+ * Predefined material compositions for cascade simulations.
+ * Includes natural isotopic abundances, alloys, compounds, and
+ * historical LENR experiment fuel compositions.
+ *
+ * Issue #96: Weighted Fuel Proportions and Materials Catalog
+ */
+
+import type { Material, LENRExperiment } from '../types';
+
+// ============================================================================
+// Natural Isotopic Abundances
+// ============================================================================
+
+/**
+ * Natural isotopic abundances for commonly used LENR elements.
+ * These are loaded dynamically from the database using pcaNCrust field,
+ * but we provide some common ones as quick-access presets.
+ */
+export const NATURAL_ABUNDANCES: Material[] = [
+  {
+    id: 'natural-lithium',
+    name: 'Natural Lithium',
+    category: 'natural-abundance',
+    description: 'Natural lithium isotopic composition',
+    composition: [
+      { nuclideId: 'Li-7', proportion: 92.41 },
+      { nuclideId: 'Li-6', proportion: 7.59 },
+    ],
+    source: 'IUPAC 2016 atomic weights',
+    tags: ['lithium', 'natural', 'fuel'],
+  },
+  {
+    id: 'natural-nickel',
+    name: 'Natural Nickel',
+    category: 'natural-abundance',
+    description: 'Natural nickel isotopic composition',
+    composition: [
+      { nuclideId: 'Ni-58', proportion: 68.077 },
+      { nuclideId: 'Ni-60', proportion: 26.223 },
+      { nuclideId: 'Ni-61', proportion: 1.140 },
+      { nuclideId: 'Ni-62', proportion: 3.635 },
+      { nuclideId: 'Ni-64', proportion: 0.926 },
+    ],
+    source: 'IUPAC 2016 atomic weights',
+    tags: ['nickel', 'natural', 'fuel', 'ni-h'],
+  },
+  {
+    id: 'natural-hydrogen',
+    name: 'Natural Hydrogen',
+    category: 'natural-abundance',
+    description: 'Natural hydrogen isotopic composition',
+    composition: [
+      { nuclideId: 'H-1', proportion: 99.9885 },
+      { nuclideId: 'D', proportion: 0.0115 },
+    ],
+    source: 'IUPAC 2016 atomic weights',
+    tags: ['hydrogen', 'natural', 'fuel'],
+  },
+  {
+    id: 'natural-boron',
+    name: 'Natural Boron',
+    category: 'natural-abundance',
+    description: 'Natural boron isotopic composition',
+    composition: [
+      { nuclideId: 'B-11', proportion: 80.1 },
+      { nuclideId: 'B-10', proportion: 19.9 },
+    ],
+    source: 'IUPAC 2016 atomic weights',
+    tags: ['boron', 'natural', 'fuel'],
+  },
+  {
+    id: 'natural-iron',
+    name: 'Natural Iron',
+    category: 'natural-abundance',
+    description: 'Natural iron isotopic composition',
+    composition: [
+      { nuclideId: 'Fe-56', proportion: 91.754 },
+      { nuclideId: 'Fe-54', proportion: 5.845 },
+      { nuclideId: 'Fe-57', proportion: 2.119 },
+      { nuclideId: 'Fe-58', proportion: 0.282 },
+    ],
+    source: 'IUPAC 2016 atomic weights',
+    tags: ['iron', 'natural', 'steel'],
+  },
+  {
+    id: 'natural-copper',
+    name: 'Natural Copper',
+    category: 'natural-abundance',
+    description: 'Natural copper isotopic composition',
+    composition: [
+      { nuclideId: 'Cu-63', proportion: 69.17 },
+      { nuclideId: 'Cu-65', proportion: 30.83 },
+    ],
+    source: 'IUPAC 2016 atomic weights',
+    tags: ['copper', 'natural', 'constantan'],
+  },
+  {
+    id: 'natural-titanium',
+    name: 'Natural Titanium',
+    category: 'natural-abundance',
+    description: 'Natural titanium isotopic composition',
+    composition: [
+      { nuclideId: 'Ti-48', proportion: 73.72 },
+      { nuclideId: 'Ti-46', proportion: 8.25 },
+      { nuclideId: 'Ti-47', proportion: 7.44 },
+      { nuclideId: 'Ti-49', proportion: 5.41 },
+      { nuclideId: 'Ti-50', proportion: 5.18 },
+    ],
+    source: 'IUPAC 2016 atomic weights',
+    tags: ['titanium', 'natural', 'aerospace'],
+  },
+  {
+    id: 'natural-chromium',
+    name: 'Natural Chromium',
+    category: 'natural-abundance',
+    description: 'Natural chromium isotopic composition',
+    composition: [
+      { nuclideId: 'Cr-52', proportion: 83.789 },
+      { nuclideId: 'Cr-53', proportion: 9.501 },
+      { nuclideId: 'Cr-50', proportion: 4.345 },
+      { nuclideId: 'Cr-54', proportion: 2.365 },
+    ],
+    source: 'IUPAC 2016 atomic weights',
+    tags: ['chromium', 'natural', 'steel'],
+  },
+  {
+    id: 'natural-aluminum',
+    name: 'Natural Aluminum',
+    category: 'natural-abundance',
+    description: 'Aluminum has only one stable isotope',
+    composition: [
+      { nuclideId: 'Al-27', proportion: 100 },
+    ],
+    source: 'IUPAC 2016 atomic weights',
+    tags: ['aluminum', 'natural', 'monoisotopic'],
+  },
+];
+
+// ============================================================================
+// Common Alloys
+// ============================================================================
+
+export const ALLOYS: Material[] = [
+  {
+    id: 'ss-304',
+    name: 'Stainless Steel 304',
+    category: 'alloy',
+    description: 'Common austenitic stainless steel (18-8)',
+    composition: [
+      // Iron (~69.5% of alloy, natural isotopes)
+      { nuclideId: 'Fe-56', proportion: 63.77 },
+      { nuclideId: 'Fe-54', proportion: 4.06 },
+      { nuclideId: 'Fe-57', proportion: 1.47 },
+      { nuclideId: 'Fe-58', proportion: 0.20 },
+      // Chromium (18.5% of alloy, natural isotopes)
+      { nuclideId: 'Cr-52', proportion: 15.50 },
+      { nuclideId: 'Cr-53', proportion: 1.76 },
+      { nuclideId: 'Cr-50', proportion: 0.80 },
+      { nuclideId: 'Cr-54', proportion: 0.44 },
+      // Nickel (9.5% of alloy, natural isotopes)
+      { nuclideId: 'Ni-58', proportion: 6.47 },
+      { nuclideId: 'Ni-60', proportion: 2.49 },
+      { nuclideId: 'Ni-61', proportion: 0.11 },
+      { nuclideId: 'Ni-62', proportion: 0.35 },
+      { nuclideId: 'Ni-64', proportion: 0.09 },
+      // Manganese (2% of alloy, assume Mn-55 monoisotopic)
+      { nuclideId: 'Mn-55', proportion: 2.00 },
+      // Silicon (0.5% of alloy)
+      { nuclideId: 'Si-28', proportion: 0.46 },
+      { nuclideId: 'Si-29', proportion: 0.02 },
+      { nuclideId: 'Si-30', proportion: 0.02 },
+    ],
+    source: 'ASTM A240 specification',
+    tags: ['steel', 'stainless', '304', 'austenitic', 'reactor'],
+  },
+  {
+    id: 'ss-316',
+    name: 'Stainless Steel 316',
+    category: 'alloy',
+    description: 'Molybdenum-bearing stainless steel',
+    composition: [
+      // Iron (~65% of alloy, natural isotopes)
+      { nuclideId: 'Fe-56', proportion: 59.64 },
+      { nuclideId: 'Fe-54', proportion: 3.80 },
+      { nuclideId: 'Fe-57', proportion: 1.38 },
+      { nuclideId: 'Fe-58', proportion: 0.18 },
+      // Chromium (17% of alloy)
+      { nuclideId: 'Cr-52', proportion: 14.24 },
+      { nuclideId: 'Cr-53', proportion: 1.62 },
+      { nuclideId: 'Cr-50', proportion: 0.74 },
+      { nuclideId: 'Cr-54', proportion: 0.40 },
+      // Nickel (12% of alloy)
+      { nuclideId: 'Ni-58', proportion: 8.17 },
+      { nuclideId: 'Ni-60', proportion: 3.15 },
+      { nuclideId: 'Ni-61', proportion: 0.14 },
+      { nuclideId: 'Ni-62', proportion: 0.44 },
+      { nuclideId: 'Ni-64', proportion: 0.11 },
+      // Molybdenum (2.5% of alloy)
+      { nuclideId: 'Mo-98', proportion: 0.60 },
+      { nuclideId: 'Mo-96', proportion: 0.42 },
+      { nuclideId: 'Mo-95', proportion: 0.40 },
+      { nuclideId: 'Mo-92', proportion: 0.37 },
+      { nuclideId: 'Mo-100', proportion: 0.24 },
+      { nuclideId: 'Mo-97', proportion: 0.24 },
+      { nuclideId: 'Mo-94', proportion: 0.23 },
+      // Manganese (2% of alloy)
+      { nuclideId: 'Mn-55', proportion: 2.00 },
+    ],
+    source: 'ASTM A240 specification',
+    tags: ['steel', 'stainless', '316', 'austenitic', 'moly'],
+  },
+  {
+    id: 'constantan',
+    name: 'Constantan',
+    category: 'alloy',
+    description: 'Cu-Ni alloy used in Celani experiments (55% Cu, 45% Ni)',
+    composition: [
+      // Copper (55% of alloy, natural isotopes)
+      { nuclideId: 'Cu-63', proportion: 38.04 },
+      { nuclideId: 'Cu-65', proportion: 16.96 },
+      // Nickel (45% of alloy, natural isotopes)
+      { nuclideId: 'Ni-58', proportion: 30.63 },
+      { nuclideId: 'Ni-60', proportion: 11.80 },
+      { nuclideId: 'Ni-61', proportion: 0.51 },
+      { nuclideId: 'Ni-62', proportion: 1.64 },
+      { nuclideId: 'Ni-64', proportion: 0.42 },
+    ],
+    source: 'Standard constantan composition',
+    tags: ['constantan', 'copper', 'nickel', 'celani', 'thermocouple'],
+  },
+  {
+    id: 'ti-6al-4v',
+    name: 'Ti-6Al-4V',
+    category: 'alloy',
+    description: 'Aerospace titanium alloy (Grade 5)',
+    composition: [
+      // Titanium (90% of alloy, natural isotopes)
+      { nuclideId: 'Ti-48', proportion: 66.35 },
+      { nuclideId: 'Ti-46', proportion: 7.43 },
+      { nuclideId: 'Ti-47', proportion: 6.70 },
+      { nuclideId: 'Ti-49', proportion: 4.87 },
+      { nuclideId: 'Ti-50', proportion: 4.66 },
+      // Aluminum (6% of alloy)
+      { nuclideId: 'Al-27', proportion: 6.00 },
+      // Vanadium (4% of alloy, natural isotopes)
+      { nuclideId: 'V-51', proportion: 3.99 },
+      { nuclideId: 'V-50', proportion: 0.01 },
+    ],
+    source: 'ASTM B348 Grade 5',
+    tags: ['titanium', 'aerospace', 'grade5', 'ti64'],
+  },
+];
+
+// ============================================================================
+// Chemical Compounds
+// ============================================================================
+
+export const COMPOUNDS: Material[] = [
+  {
+    id: 'lialh4',
+    name: 'LiAlH4 (Natural)',
+    category: 'compound',
+    description: 'Lithium aluminum hydride - common LENR fuel additive',
+    composition: [
+      // Lithium (1 atom per formula unit)
+      { nuclideId: 'Li-7', proportion: 7.88 },   // ~16.6% of mass, 92.41% Li-7
+      { nuclideId: 'Li-6', proportion: 0.65 },   // 7.59% Li-6
+      // Aluminum (1 atom per formula unit, ~71.1% of mass)
+      { nuclideId: 'Al-27', proportion: 71.10 },
+      // Hydrogen (4 atoms per formula unit, ~10.6% of mass)
+      { nuclideId: 'H-1', proportion: 10.59 },
+      { nuclideId: 'D', proportion: 0.001 },     // Natural deuterium trace
+    ],
+    source: 'Stoichiometric calculation with natural isotopes',
+    tags: ['hydride', 'lithium', 'aluminum', 'hydrogen', 'parkhomov', 'fuel'],
+  },
+  {
+    id: 'nabh4',
+    name: 'NaBH4 (Natural)',
+    category: 'compound',
+    description: 'Sodium borohydride',
+    composition: [
+      // Sodium (1 atom, ~60.8% of mass)
+      { nuclideId: 'Na-23', proportion: 60.80 },
+      // Boron (1 atom, ~28.6% of mass)
+      { nuclideId: 'B-11', proportion: 22.91 },
+      { nuclideId: 'B-10', proportion: 5.69 },
+      // Hydrogen (4 atoms, ~10.6% of mass)
+      { nuclideId: 'H-1', proportion: 10.59 },
+      { nuclideId: 'D', proportion: 0.001 },
+    ],
+    source: 'Stoichiometric calculation with natural isotopes',
+    tags: ['hydride', 'sodium', 'boron', 'hydrogen', 'fuel'],
+  },
+  {
+    id: 'mgh2',
+    name: 'MgH2 (Natural)',
+    category: 'compound',
+    description: 'Magnesium hydride - hydrogen storage material',
+    composition: [
+      // Magnesium (1 atom, ~92.3% of mass)
+      { nuclideId: 'Mg-24', proportion: 72.92 },
+      { nuclideId: 'Mg-25', proportion: 9.23 },
+      { nuclideId: 'Mg-26', proportion: 10.15 },
+      // Hydrogen (2 atoms, ~7.7% of mass)
+      { nuclideId: 'H-1', proportion: 7.69 },
+      { nuclideId: 'D', proportion: 0.001 },
+    ],
+    source: 'Stoichiometric calculation with natural isotopes',
+    tags: ['hydride', 'magnesium', 'hydrogen', 'storage'],
+  },
+  {
+    id: 'pd-d',
+    name: 'Palladium Deuteride',
+    category: 'compound',
+    description: 'PdD (loaded palladium electrode)',
+    composition: [
+      // Palladium (natural isotopes)
+      { nuclideId: 'Pd-106', proportion: 25.02 },
+      { nuclideId: 'Pd-108', proportion: 24.30 },
+      { nuclideId: 'Pd-105', proportion: 20.45 },
+      { nuclideId: 'Pd-110', proportion: 10.76 },
+      { nuclideId: 'Pd-104', proportion: 10.22 },
+      { nuclideId: 'Pd-102', proportion: 0.94 },
+      // Deuterium (typical 1:1 loading ratio, ~1.9% by mass)
+      { nuclideId: 'D', proportion: 8.31 },
+    ],
+    source: 'Typical electrolysis experiment loading',
+    tags: ['palladium', 'deuterium', 'fleischmann', 'pons', 'electrolysis'],
+  },
+];
+
+// ============================================================================
+// Historical LENR Experiments
+// ============================================================================
+
+export const LENR_EXPERIMENTS: LENRExperiment[] = [
+  {
+    id: 'parkhomov-2014',
+    name: 'Parkhomov Ni-LiAlH4',
+    category: 'lenr-experiment',
+    description: 'Alexander Parkhomov\'s 2014 replication of Rossi reactor',
+    researcher: 'Alexander Parkhomov',
+    year: 2014,
+    composition: [
+      // Nickel powder (~90% of active fuel)
+      { nuclideId: 'Ni-58', proportion: 61.27 },
+      { nuclideId: 'Ni-60', proportion: 23.60 },
+      { nuclideId: 'Ni-61', proportion: 1.03 },
+      { nuclideId: 'Ni-62', proportion: 3.27 },
+      { nuclideId: 'Ni-64', proportion: 0.83 },
+      // LiAlH4 (~10% of active fuel)
+      { nuclideId: 'Li-7', proportion: 0.79 },
+      { nuclideId: 'Li-6', proportion: 0.07 },
+      { nuclideId: 'Al-27', proportion: 7.11 },
+      { nuclideId: 'H-1', proportion: 1.06 },
+    ],
+    citation: 'Parkhomov, A.G. (2015). "Investigation of high-temperature heat generator similar to the Rossi reactor"',
+    experimentType: 'Ni-H',
+    source: 'http://www.e-catworld.com/2015/01/07/parkhomov-reports-successful-replication-of-rossi-reactor/',
+    tags: ['parkhomov', 'nickel', 'hydrogen', 'lialh4', 'replication'],
+  },
+  {
+    id: 'piantelli-1990',
+    name: 'Piantelli Ni-H System',
+    category: 'lenr-experiment',
+    description: 'Francesco Piantelli\'s nickel-hydrogen experiments (1990s)',
+    researcher: 'Francesco Piantelli',
+    year: 1990,
+    composition: [
+      // Natural nickel rod
+      { nuclideId: 'Ni-58', proportion: 67.40 },
+      { nuclideId: 'Ni-60', proportion: 25.97 },
+      { nuclideId: 'Ni-61', proportion: 1.13 },
+      { nuclideId: 'Ni-62', proportion: 3.60 },
+      { nuclideId: 'Ni-64', proportion: 0.92 },
+      // Hydrogen gas loading
+      { nuclideId: 'H-1', proportion: 0.97 },
+      { nuclideId: 'D', proportion: 0.001 },
+    ],
+    citation: 'Focardi, S., et al. (1998). "Large excess heat production in Ni-H systems"',
+    experimentType: 'Ni-H',
+    source: 'Il Nuovo Cimento A, 111(11), 1233-1242',
+    tags: ['piantelli', 'focardi', 'nickel', 'hydrogen', 'italy'],
+  },
+  {
+    id: 'celani-2012',
+    name: 'Celani Constantan Wire',
+    category: 'lenr-experiment',
+    description: 'Francesco Celani\'s hydrogen-loaded constantan wire experiments',
+    researcher: 'Francesco Celani',
+    year: 2012,
+    composition: [
+      // Constantan wire (55% Cu, 45% Ni)
+      { nuclideId: 'Cu-63', proportion: 37.67 },
+      { nuclideId: 'Cu-65', proportion: 16.79 },
+      { nuclideId: 'Ni-58', proportion: 30.32 },
+      { nuclideId: 'Ni-60', proportion: 11.68 },
+      { nuclideId: 'Ni-61', proportion: 0.51 },
+      { nuclideId: 'Ni-62', proportion: 1.62 },
+      { nuclideId: 'Ni-64', proportion: 0.41 },
+      // Hydrogen loading
+      { nuclideId: 'H-1', proportion: 0.99 },
+      { nuclideId: 'D', proportion: 0.001 },
+    ],
+    citation: 'Celani, F., et al. (2012). ICCF-17 Proceedings',
+    experimentType: 'Cu-Ni-H',
+    source: 'https://www.lenr-canr.org/',
+    tags: ['celani', 'constantan', 'copper', 'nickel', 'hydrogen', 'wire'],
+  },
+  {
+    id: 'shoulders-evo',
+    name: 'Shoulders EVO Titanium',
+    category: 'lenr-experiment',
+    description: 'Ken Shoulders\' Exotic Vacuum Objects experiments with titanium',
+    researcher: 'Ken Shoulders',
+    year: 1995,
+    composition: [
+      // Titanium substrate (natural isotopes)
+      { nuclideId: 'Ti-48', proportion: 72.65 },
+      { nuclideId: 'Ti-46', proportion: 8.13 },
+      { nuclideId: 'Ti-47', proportion: 7.33 },
+      { nuclideId: 'Ti-49', proportion: 5.33 },
+      { nuclideId: 'Ti-50', proportion: 5.10 },
+      // Deuterium loading
+      { nuclideId: 'D', proportion: 1.46 },
+    ],
+    citation: 'Shoulders, K.R., & Shoulders, S. (1996). "Observations on the role of charge clusters in nuclear cluster reactions"',
+    experimentType: 'EVO',
+    source: 'Journal of New Energy, 1(3), 1996',
+    tags: ['shoulders', 'evo', 'titanium', 'deuterium', 'charge-clusters'],
+  },
+  {
+    id: 'urutskoev-2000',
+    name: 'Urutskoev Ti Foil Explosion',
+    category: 'lenr-experiment',
+    description: 'L.I. Urutskoev\'s exploding titanium foil experiments',
+    researcher: 'L.I. Urutskoev',
+    year: 2000,
+    composition: [
+      // Titanium foil (natural isotopes)
+      { nuclideId: 'Ti-48', proportion: 73.72 },
+      { nuclideId: 'Ti-46', proportion: 8.25 },
+      { nuclideId: 'Ti-47', proportion: 7.44 },
+      { nuclideId: 'Ti-49', proportion: 5.41 },
+      { nuclideId: 'Ti-50', proportion: 5.18 },
+    ],
+    citation: 'Urutskoev, L.I., et al. (2000). "Experimental detection of strange radiation..."',
+    experimentType: 'Electrical discharge',
+    source: 'Annales Fondation Louis de Broglie, 27, 701',
+    tags: ['urutskoev', 'titanium', 'explosion', 'discharge', 'russia'],
+  },
+  {
+    id: 'matsumoto-1992',
+    name: 'Matsumoto Carbon Arc',
+    category: 'lenr-experiment',
+    description: 'Takaaki Matsumoto\'s carbon arc discharge experiments',
+    researcher: 'Takaaki Matsumoto',
+    year: 1992,
+    composition: [
+      // Carbon electrodes (natural isotopes)
+      { nuclideId: 'C-12', proportion: 98.89 },
+      { nuclideId: 'C-13', proportion: 1.11 },
+    ],
+    citation: 'Matsumoto, T. (1993). Fusion Technology, 24, 296',
+    experimentType: 'Arc discharge',
+    source: 'https://www.lenr-canr.org/',
+    tags: ['matsumoto', 'carbon', 'arc', 'discharge', 'japan'],
+  },
+  {
+    id: 'mizuno-pd-d',
+    name: 'Mizuno Pd-D Electrolysis',
+    category: 'lenr-experiment',
+    description: 'Tadahiko Mizuno\'s palladium deuterium electrolysis experiments',
+    researcher: 'Tadahiko Mizuno',
+    year: 1996,
+    composition: [
+      // Palladium cathode (natural isotopes)
+      { nuclideId: 'Pd-106', proportion: 25.02 },
+      { nuclideId: 'Pd-108', proportion: 24.30 },
+      { nuclideId: 'Pd-105', proportion: 20.45 },
+      { nuclideId: 'Pd-110', proportion: 10.76 },
+      { nuclideId: 'Pd-104', proportion: 10.22 },
+      { nuclideId: 'Pd-102', proportion: 0.94 },
+      // Deuterium from D2O electrolysis
+      { nuclideId: 'D', proportion: 8.31 },
+    ],
+    citation: 'Mizuno, T. (1998). "Nuclear Transmutation: The Reality of Cold Fusion"',
+    experimentType: 'Pd-D electrolysis',
+    source: 'Infinite Energy Press, ISBN 978-1892925008',
+    tags: ['mizuno', 'palladium', 'deuterium', 'electrolysis', 'japan'],
+  },
+];
+
+// ============================================================================
+// Export All Materials
+// ============================================================================
+
+/**
+ * All built-in materials combined
+ */
+export const ALL_BUILTIN_MATERIALS: (Material | LENRExperiment)[] = [
+  ...NATURAL_ABUNDANCES,
+  ...ALLOYS,
+  ...COMPOUNDS,
+  ...LENR_EXPERIMENTS,
+];
+
+/**
+ * Get materials by category
+ */
+export function getMaterialsByCategory(category: string): Material[] {
+  return ALL_BUILTIN_MATERIALS.filter((m) => m.category === category);
+}
+
+/**
+ * Get material by ID
+ */
+export function getMaterialById(id: string): Material | undefined {
+  return ALL_BUILTIN_MATERIALS.find((m) => m.id === id);
+}

--- a/src/constants/materials.ts
+++ b/src/constants/materials.ts
@@ -38,11 +38,11 @@ export const NATURAL_ABUNDANCES: Material[] = [
     category: 'natural-abundance',
     description: 'Natural nickel isotopic composition',
     composition: [
-      { nuclideId: 'Ni-58', proportion: 68.077 },
-      { nuclideId: 'Ni-60', proportion: 26.223 },
-      { nuclideId: 'Ni-61', proportion: 1.140 },
-      { nuclideId: 'Ni-62', proportion: 3.635 },
-      { nuclideId: 'Ni-64', proportion: 0.926 },
+      { nuclideId: 'Ni-58', proportion: 68.08 },
+      { nuclideId: 'Ni-60', proportion: 26.22 },
+      { nuclideId: 'Ni-61', proportion: 1.14 },
+      { nuclideId: 'Ni-62', proportion: 3.63 },
+      { nuclideId: 'Ni-64', proportion: 0.93 },
     ],
     source: 'IUPAC 2016 atomic weights',
     tags: ['nickel', 'natural', 'fuel', 'ni-h'],
@@ -53,8 +53,8 @@ export const NATURAL_ABUNDANCES: Material[] = [
     category: 'natural-abundance',
     description: 'Natural hydrogen isotopic composition',
     composition: [
-      { nuclideId: 'H-1', proportion: 99.9885 },
-      { nuclideId: 'D', proportion: 0.0115 },
+      { nuclideId: 'H-1', proportion: 99.99 },
+      { nuclideId: 'D', proportion: 0.01 },
     ],
     source: 'IUPAC 2016 atomic weights',
     tags: ['hydrogen', 'natural', 'fuel'],
@@ -77,10 +77,10 @@ export const NATURAL_ABUNDANCES: Material[] = [
     category: 'natural-abundance',
     description: 'Natural iron isotopic composition',
     composition: [
-      { nuclideId: 'Fe-56', proportion: 91.754 },
-      { nuclideId: 'Fe-54', proportion: 5.845 },
-      { nuclideId: 'Fe-57', proportion: 2.119 },
-      { nuclideId: 'Fe-58', proportion: 0.282 },
+      { nuclideId: 'Fe-56', proportion: 91.75 },
+      { nuclideId: 'Fe-54', proportion: 5.85 },
+      { nuclideId: 'Fe-57', proportion: 2.12 },
+      { nuclideId: 'Fe-58', proportion: 0.28 },
     ],
     source: 'IUPAC 2016 atomic weights',
     tags: ['iron', 'natural', 'steel'],
@@ -118,10 +118,10 @@ export const NATURAL_ABUNDANCES: Material[] = [
     category: 'natural-abundance',
     description: 'Natural chromium isotopic composition',
     composition: [
-      { nuclideId: 'Cr-52', proportion: 83.789 },
-      { nuclideId: 'Cr-53', proportion: 9.501 },
-      { nuclideId: 'Cr-50', proportion: 4.345 },
-      { nuclideId: 'Cr-54', proportion: 2.365 },
+      { nuclideId: 'Cr-52', proportion: 83.79 },
+      { nuclideId: 'Cr-53', proportion: 9.50 },
+      { nuclideId: 'Cr-50', proportion: 4.35 },
+      { nuclideId: 'Cr-54', proportion: 2.37 },
     ],
     source: 'IUPAC 2016 atomic weights',
     tags: ['chromium', 'natural', 'steel'],
@@ -136,6 +136,27 @@ export const NATURAL_ABUNDANCES: Material[] = [
     ],
     source: 'IUPAC 2016 atomic weights',
     tags: ['aluminum', 'natural', 'monoisotopic'],
+  },
+  {
+    id: 'natural-air',
+    name: 'Natural Air',
+    category: 'natural-abundance',
+    description: 'Dry atmospheric air composition (N₂ 78%, O₂ 21%, Ar 0.93%)',
+    composition: [
+      // Nitrogen (78.08% by volume, ~75.5% by mass)
+      { nuclideId: 'N-14', proportion: 75.07 },
+      { nuclideId: 'N-15', proportion: 0.27 },
+      // Oxygen (20.95% by volume, ~23.1% by mass)
+      { nuclideId: 'O-16', proportion: 23.01 },
+      { nuclideId: 'O-18', proportion: 0.05 },
+      { nuclideId: 'O-17', proportion: 0.01 },
+      // Argon (0.93% by volume, ~1.3% by mass)
+      { nuclideId: 'Ar-40', proportion: 1.29 },
+      // Trace components below 0.01% omitted for simplicity
+      // (Ar-36: 0.004%, Ar-38: 0.001%, CO2: 0.04%)
+    ],
+    source: 'CRC Handbook of Chemistry and Physics',
+    tags: ['air', 'atmosphere', 'natural', 'nitrogen', 'oxygen', 'argon'],
   },
 ];
 
@@ -265,14 +286,13 @@ export const COMPOUNDS: Material[] = [
     category: 'compound',
     description: 'Lithium aluminum hydride - common LENR fuel additive',
     composition: [
-      // Lithium (1 atom per formula unit)
-      { nuclideId: 'Li-7', proportion: 7.88 },   // ~16.6% of mass, 92.41% Li-7
-      { nuclideId: 'Li-6', proportion: 0.65 },   // 7.59% Li-6
       // Aluminum (1 atom per formula unit, ~71.1% of mass)
       { nuclideId: 'Al-27', proportion: 71.10 },
       // Hydrogen (4 atoms per formula unit, ~10.6% of mass)
       { nuclideId: 'H-1', proportion: 10.59 },
-      { nuclideId: 'D', proportion: 0.001 },     // Natural deuterium trace
+      // Lithium (1 atom per formula unit, ~18.3% of mass)
+      { nuclideId: 'Li-7', proportion: 16.93 },
+      { nuclideId: 'Li-6', proportion: 1.38 },
     ],
     source: 'Stoichiometric calculation with natural isotopes',
     tags: ['hydride', 'lithium', 'aluminum', 'hydrogen', 'parkhomov', 'fuel'],
@@ -289,8 +309,7 @@ export const COMPOUNDS: Material[] = [
       { nuclideId: 'B-11', proportion: 22.91 },
       { nuclideId: 'B-10', proportion: 5.69 },
       // Hydrogen (4 atoms, ~10.6% of mass)
-      { nuclideId: 'H-1', proportion: 10.59 },
-      { nuclideId: 'D', proportion: 0.001 },
+      { nuclideId: 'H-1', proportion: 10.60 },
     ],
     source: 'Stoichiometric calculation with natural isotopes',
     tags: ['hydride', 'sodium', 'boron', 'hydrogen', 'fuel'],
@@ -306,8 +325,7 @@ export const COMPOUNDS: Material[] = [
       { nuclideId: 'Mg-25', proportion: 9.23 },
       { nuclideId: 'Mg-26', proportion: 10.15 },
       // Hydrogen (2 atoms, ~7.7% of mass)
-      { nuclideId: 'H-1', proportion: 7.69 },
-      { nuclideId: 'D', proportion: 0.001 },
+      { nuclideId: 'H-1', proportion: 7.70 },
     ],
     source: 'Stoichiometric calculation with natural isotopes',
     tags: ['hydride', 'magnesium', 'hydrogen', 'storage'],
@@ -377,9 +395,8 @@ export const LENR_EXPERIMENTS: LENRExperiment[] = [
       { nuclideId: 'Ni-61', proportion: 1.13 },
       { nuclideId: 'Ni-62', proportion: 3.60 },
       { nuclideId: 'Ni-64', proportion: 0.92 },
-      // Hydrogen gas loading
-      { nuclideId: 'H-1', proportion: 0.97 },
-      { nuclideId: 'D', proportion: 0.001 },
+      // Hydrogen gas loading (~1% by mass)
+      { nuclideId: 'H-1', proportion: 0.98 },
     ],
     citation: 'Focardi, S., et al. (1998). "Large excess heat production in Ni-H systems"',
     experimentType: 'Ni-H',
@@ -402,9 +419,8 @@ export const LENR_EXPERIMENTS: LENRExperiment[] = [
       { nuclideId: 'Ni-61', proportion: 0.51 },
       { nuclideId: 'Ni-62', proportion: 1.62 },
       { nuclideId: 'Ni-64', proportion: 0.41 },
-      // Hydrogen loading
-      { nuclideId: 'H-1', proportion: 0.99 },
-      { nuclideId: 'D', proportion: 0.001 },
+      // Hydrogen loading (~1% by mass)
+      { nuclideId: 'H-1', proportion: 1.00 },
     ],
     citation: 'Celani, F., et al. (2012). ICCF-17 Proceedings',
     experimentType: 'Cu-Ni-H',

--- a/src/pages/CascadesAll.tsx
+++ b/src/pages/CascadesAll.tsx
@@ -1,13 +1,16 @@
 import { useState, useEffect } from 'react'
-import { Play, Settings, AlertCircle, CheckCircle, XCircle, Loader2, Download } from 'lucide-react'
+import { Play, Settings, AlertCircle, CheckCircle, XCircle, Loader2, Download, Scale, BookOpen } from 'lucide-react'
 import { useDatabase } from '../contexts/DatabaseContext'
 import { useQueryState } from '../contexts/QueryStateContext'
 import { useCascadeWorker } from '../hooks/useCascadeWorker'
 import CascadeProgressCard from '../components/CascadeProgressCard'
 import CascadeTabs from '../components/CascadeTabs'
 import PeriodicTableSelector from '../components/PeriodicTableSelector'
+import ProportionInput from '../components/ProportionInput'
+import MaterialsCatalog from '../components/MaterialsCatalog'
 import { getAllElements } from '../services/queryService'
-import type { CascadeResults, Element } from '../types'
+import { createEqualProportions } from '../services/proportionService'
+import type { CascadeResults, Element, WeightedNuclide, ProportionFormat } from '../types'
 
 export default function CascadesAll() {
   const { db } = useDatabase()
@@ -37,6 +40,12 @@ export default function CascadesAll() {
   const [results, setResults] = useState<CascadeResults | null>(null)
   const [error, setError] = useState<string | null>(null)
 
+  // Weighted mode state (Issue #96)
+  const [useWeightedMode, setUseWeightedMode] = useState(false)
+  const [weightedFuel, setWeightedFuel] = useState<WeightedNuclide[]>([])
+  const [proportionFormat, setProportionFormat] = useState<ProportionFormat>('percentage')
+  const [showMaterialsCatalog, setShowMaterialsCatalog] = useState(false)
+
   // Load available elements and restore state when database is ready
   useEffect(() => {
     if (db) {
@@ -63,6 +72,17 @@ export default function CascadesAll() {
           setSliderMaxLoops(savedState.maxLoops)
           setFuelNuclides(savedState.fuelNuclides)
 
+          // Restore weighted mode state (Issue #96)
+          if (savedState.weightedFuel) {
+            setWeightedFuel(savedState.weightedFuel)
+          }
+          if (savedState.proportionFormat) {
+            setProportionFormat(savedState.proportionFormat)
+          }
+          if (savedState.useWeightedMode !== undefined) {
+            setUseWeightedMode(savedState.useWeightedMode)
+          }
+
           // Restore simulation results if available
           if (savedState.results) {
             setResults(savedState.results)
@@ -72,6 +92,43 @@ export default function CascadesAll() {
       }
     }
   }, [db, hasRestoredFromContext, getCascadeState])
+
+  // Sync weighted fuel with fuel nuclides
+  useEffect(() => {
+    if (fuelNuclides.length === 0) {
+      setWeightedFuel([])
+      return
+    }
+
+    // When fuel nuclides change, update weighted fuel to include new nuclides
+    // and remove any that are no longer selected
+    setWeightedFuel((prev) => {
+      const existingMap = new Map(prev.map((n) => [n.nuclideId, n]))
+
+      // Keep existing proportions for nuclides that are still selected
+      const updated: WeightedNuclide[] = []
+      for (const id of fuelNuclides) {
+        if (existingMap.has(id)) {
+          updated.push(existingMap.get(id)!)
+        } else {
+          // New nuclide - give it equal proportion
+          updated.push({
+            nuclideId: id,
+            proportion: 100 / fuelNuclides.length,
+            sourceType: 'manual',
+          })
+        }
+      }
+
+      // If proportions don't make sense anymore, redistribute equally
+      const total = updated.reduce((sum, n) => sum + n.proportion, 0)
+      if (total === 0 || updated.length !== prev.length) {
+        return createEqualProportions(fuelNuclides, 'manual')
+      }
+
+      return updated
+    })
+  }, [fuelNuclides])
 
   // Save state to context whenever it changes
   useEffect(() => {
@@ -90,6 +147,10 @@ export default function CascadesAll() {
       excludeBoiledOff: params.excludeBoiledOff,
       fuelNuclides,
       results: results || undefined,
+      // Weighted mode state (Issue #96)
+      weightedFuel: weightedFuel.length > 0 ? weightedFuel : undefined,
+      proportionFormat,
+      useWeightedMode,
     })
   }, [
     hasRestoredFromContext,
@@ -105,6 +166,9 @@ export default function CascadesAll() {
     params.excludeBoiledOff,
     fuelNuclides,
     results,
+    weightedFuel,
+    proportionFormat,
+    useWeightedMode,
     updateCascadeState,
   ])
 
@@ -126,10 +190,15 @@ export default function CascadesAll() {
       // Export database to ArrayBuffer for worker
       const dbBuffer = db.export().buffer
 
-      // Run cascade in worker
+      // Run cascade in worker (with weighted mode support - Issue #96)
       const cascadeResults = await runCascade({
         fuelNuclides: fuelNuclides,
         ...params,
+        // Include weighted fuel configuration when enabled
+        ...(useWeightedMode && weightedFuel.length > 0 ? {
+          weightedFuel,
+          useWeightedMode: true,
+        } : {}),
       }, dbBuffer as ArrayBuffer)
 
       setResults(cascadeResults)
@@ -158,6 +227,19 @@ export default function CascadesAll() {
     setFuelNuclides(['H-1', 'Li-7', 'Al-27', 'N-14', 'Ni-58', 'Ni-60', 'Ni-62', 'B-10', 'B-11'])
     setResults(null)
     setError(null)
+    // Reset weighted mode state
+    setUseWeightedMode(false)
+    setWeightedFuel([])
+    setProportionFormat('percentage')
+  }
+
+  // Handle material selection from catalog
+  const handleMaterialSelect = (nuclides: WeightedNuclide[]) => {
+    // Extract unique nuclide IDs and update fuel selection
+    const nuclideIds = nuclides.map((n) => n.nuclideId)
+    setFuelNuclides(nuclideIds)
+    setWeightedFuel(nuclides)
+    setUseWeightedMode(true) // Enable weighted mode when loading a material
   }
 
   const handleDownloadCSV = () => {
@@ -227,7 +309,45 @@ export default function CascadesAll() {
       </div>
 
       <div className="card p-6 mb-6">
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">Fuel Nuclides</h2>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Fuel Nuclides</h2>
+          <div className="flex items-center gap-4">
+            {/* Weighted Mode Toggle */}
+            <label className="flex items-center gap-2 cursor-pointer">
+              <div className="relative">
+                <input
+                  type="checkbox"
+                  checked={useWeightedMode}
+                  onChange={(e) => setUseWeightedMode(e.target.checked)}
+                  className="sr-only"
+                  data-testid="weighted-mode-toggle"
+                />
+                <div className={`w-10 h-6 rounded-full transition-colors ${
+                  useWeightedMode ? 'bg-primary-600' : 'bg-gray-300 dark:bg-gray-600'
+                }`}>
+                  <div className={`absolute top-1 left-1 w-4 h-4 rounded-full bg-white transition-transform ${
+                    useWeightedMode ? 'translate-x-4' : ''
+                  }`} />
+                </div>
+              </div>
+              <span className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-1.5">
+                <Scale className="w-4 h-4" />
+                Weighted Mode
+              </span>
+            </label>
+            {/* Materials Catalog Button */}
+            <button
+              type="button"
+              onClick={() => setShowMaterialsCatalog(true)}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+              data-testid="materials-catalog-button"
+            >
+              <BookOpen className="w-4 h-4" />
+              Materials
+            </button>
+          </div>
+        </div>
+
         <PeriodicTableSelector
           label="Select specific isotopes for your fuel mixture"
           availableElements={availableElements}
@@ -239,6 +359,36 @@ export default function CascadesAll() {
         <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
           Click on elements to select specific isotopes. Color coding indicates natural abundance.
         </p>
+
+        {/* Weighted Proportions Input (shown when weighted mode is enabled) */}
+        {useWeightedMode && fuelNuclides.length > 0 && (
+          <div className="mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
+            <ProportionInput
+              nuclideIds={fuelNuclides}
+              weightedNuclides={weightedFuel}
+              onProportionsChange={setWeightedFuel}
+              format={proportionFormat}
+              onFormatChange={setProportionFormat}
+              db={db}
+              showFormatSelector={true}
+              testId="fuel-proportion-input"
+            />
+          </div>
+        )}
+
+        {/* Weighted Mode Info */}
+        {useWeightedMode && (
+          <div className="mt-4 p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800">
+            <div className="flex items-start gap-2">
+              <Scale className="w-4 h-4 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" />
+              <div className="text-sm text-blue-700 dark:text-blue-300">
+                <strong>Weighted Mode:</strong> Pathway frequencies will be weighted by fuel proportions
+                using a hybrid deterministic/Monte Carlo approach. Results reflect the probability
+                of reactions occurring based on relative abundances.
+              </div>
+            </div>
+          </div>
+        )}
       </div>
 
       <div className="card p-6 mb-6">
@@ -520,6 +670,14 @@ export default function CascadesAll() {
           </ol>
         </div>
       )}
+
+      {/* Materials Catalog Modal */}
+      <MaterialsCatalog
+        isOpen={showMaterialsCatalog}
+        onClose={() => setShowMaterialsCatalog(false)}
+        onSelectMaterial={handleMaterialSelect}
+        currentFuel={weightedFuel}
+      />
     </div>
   )
 }

--- a/src/services/cascadeEngine.ts
+++ b/src/services/cascadeEngine.ts
@@ -1,6 +1,7 @@
 import type { Database } from 'sql.js';
 import type {
   CascadeParameters,
+  CascadeParametersV2,
   CascadeResults,
   CascadeReaction,
 } from '../types';
@@ -79,12 +80,12 @@ function buildNuclideId(E: string, A: number): string {
  * 3. Return complete reaction tree and statistics
  *
  * @param db - SQLite database instance
- * @param params - Cascade parameters
- * @returns Cascade simulation results
+ * @param params - Cascade parameters (supports weighted mode via CascadeParametersV2)
+ * @returns Cascade simulation results with optional weighted fuel configuration
  */
 export async function runCascadeSimulation(
   db: Database,
-  params: CascadeParameters
+  params: CascadeParameters | CascadeParametersV2
 ): Promise<CascadeResults> {
   const startTime = performance.now();
 
@@ -240,6 +241,11 @@ export async function runCascadeSimulation(
 
   const executionTime = performance.now() - startTime;
 
+  // Extract weighted mode fields if available (Issue #96)
+  const v2Params = params as CascadeParametersV2;
+  const weightedFuel = v2Params.weightedFuel;
+  const useWeightedMode = v2Params.useWeightedMode ?? false;
+
   return {
     reactions: allReactions,
     productDistribution,
@@ -249,5 +255,7 @@ export async function runCascadeSimulation(
     loopsExecuted: loopCount,
     executionTime,
     terminationReason,
+    // Include weighted configuration in results for downstream analysis
+    ...(useWeightedMode && weightedFuel ? { weightedFuel, useWeightedMode } : {}),
   };
 }

--- a/src/services/materialsService.ts
+++ b/src/services/materialsService.ts
@@ -1,0 +1,364 @@
+/**
+ * Materials Service
+ *
+ * Handles materials catalog operations including:
+ * - Loading built-in materials (alloys, compounds, LENR experiments)
+ * - Managing custom user-defined materials (localStorage)
+ * - Searching and filtering materials
+ * - Converting materials to weighted nuclides for cascade input
+ *
+ * Issue #96: Weighted Fuel Proportions and Materials Catalog
+ */
+
+import type { Database } from 'sql.js';
+import type { Material, WeightedNuclide, MaterialCategory } from '../types';
+import {
+  ALL_BUILTIN_MATERIALS,
+  NATURAL_ABUNDANCES,
+  ALLOYS,
+  COMPOUNDS,
+  LENR_EXPERIMENTS,
+  getMaterialById as getBuiltinMaterialById,
+} from '../constants/materials';
+import { getNaturalAbundances } from './proportionService';
+
+// LocalStorage key for custom materials
+const CUSTOM_MATERIALS_KEY = 'lenr-custom-materials';
+
+// ============================================================================
+// Custom Materials Management
+// ============================================================================
+
+/**
+ * Get custom materials from localStorage
+ */
+export function getCustomMaterials(): Material[] {
+  try {
+    const stored = localStorage.getItem(CUSTOM_MATERIALS_KEY);
+    if (!stored) return [];
+    return JSON.parse(stored);
+  } catch {
+    console.error('Failed to parse custom materials from localStorage');
+    return [];
+  }
+}
+
+/**
+ * Save custom materials to localStorage
+ */
+function saveCustomMaterials(materials: Material[]): void {
+  try {
+    localStorage.setItem(CUSTOM_MATERIALS_KEY, JSON.stringify(materials));
+  } catch (error) {
+    console.error('Failed to save custom materials to localStorage:', error);
+  }
+}
+
+/**
+ * Save a new custom material
+ */
+export function saveCustomMaterial(material: Omit<Material, 'id' | 'isCustom' | 'createdAt'>): Material {
+  const customMaterials = getCustomMaterials();
+
+  const newMaterial: Material = {
+    ...material,
+    id: `custom-${Date.now()}`,
+    category: 'custom',
+    isCustom: true,
+    createdAt: Date.now(),
+  };
+
+  customMaterials.push(newMaterial);
+  saveCustomMaterials(customMaterials);
+
+  return newMaterial;
+}
+
+/**
+ * Update an existing custom material
+ */
+export function updateCustomMaterial(id: string, updates: Partial<Material>): Material | null {
+  const customMaterials = getCustomMaterials();
+  const index = customMaterials.findIndex((m) => m.id === id);
+
+  if (index === -1) return null;
+
+  customMaterials[index] = {
+    ...customMaterials[index],
+    ...updates,
+    id, // Preserve original ID
+    isCustom: true,
+  };
+
+  saveCustomMaterials(customMaterials);
+  return customMaterials[index];
+}
+
+/**
+ * Delete a custom material
+ */
+export function deleteCustomMaterial(id: string): boolean {
+  const customMaterials = getCustomMaterials();
+  const index = customMaterials.findIndex((m) => m.id === id);
+
+  if (index === -1) return false;
+
+  customMaterials.splice(index, 1);
+  saveCustomMaterials(customMaterials);
+
+  return true;
+}
+
+// ============================================================================
+// Material Retrieval
+// ============================================================================
+
+/**
+ * Get all materials (built-in + custom)
+ */
+export function getAllMaterials(): Material[] {
+  return [...ALL_BUILTIN_MATERIALS, ...getCustomMaterials()];
+}
+
+/**
+ * Get materials by category
+ */
+export function getMaterialsByCategory(category: MaterialCategory): Material[] {
+  const allMaterials = getAllMaterials();
+  return allMaterials.filter((m) => m.category === category);
+}
+
+/**
+ * Get a material by ID (searches both built-in and custom)
+ */
+export function getMaterialById(id: string): Material | undefined {
+  // Check built-in first
+  const builtin = getBuiltinMaterialById(id);
+  if (builtin) return builtin;
+
+  // Check custom materials
+  const customMaterials = getCustomMaterials();
+  return customMaterials.find((m) => m.id === id);
+}
+
+/**
+ * Get natural abundance materials
+ */
+export function getNaturalAbundanceMaterials(): Material[] {
+  return [...NATURAL_ABUNDANCES];
+}
+
+/**
+ * Get alloy materials
+ */
+export function getAlloyMaterials(): Material[] {
+  return [...ALLOYS];
+}
+
+/**
+ * Get compound materials
+ */
+export function getCompoundMaterials(): Material[] {
+  return [...COMPOUNDS];
+}
+
+/**
+ * Get LENR experiment materials
+ */
+export function getLENRExperimentMaterials(): Material[] {
+  return [...LENR_EXPERIMENTS];
+}
+
+// ============================================================================
+// Search and Filtering
+// ============================================================================
+
+/**
+ * Search materials by query string
+ * Searches name, description, and tags
+ */
+export function searchMaterials(query: string): Material[] {
+  if (!query.trim()) return getAllMaterials();
+
+  const normalizedQuery = query.toLowerCase().trim();
+  const allMaterials = getAllMaterials();
+
+  return allMaterials.filter((material) => {
+    // Search in name
+    if (material.name.toLowerCase().includes(normalizedQuery)) return true;
+
+    // Search in description
+    if (material.description.toLowerCase().includes(normalizedQuery)) return true;
+
+    // Search in tags
+    if (material.tags?.some((tag) => tag.toLowerCase().includes(normalizedQuery))) return true;
+
+    // Search in nuclide IDs
+    if (material.composition.some((c) => c.nuclideId.toLowerCase().includes(normalizedQuery))) {
+      return true;
+    }
+
+    return false;
+  });
+}
+
+/**
+ * Filter materials by multiple criteria
+ */
+export interface MaterialFilter {
+  categories?: MaterialCategory[];
+  query?: string;
+  tags?: string[];
+  minNuclides?: number;
+  maxNuclides?: number;
+}
+
+export function filterMaterials(filter: MaterialFilter): Material[] {
+  let materials = getAllMaterials();
+
+  // Filter by categories
+  if (filter.categories && filter.categories.length > 0) {
+    materials = materials.filter((m) => filter.categories!.includes(m.category));
+  }
+
+  // Filter by query
+  if (filter.query && filter.query.trim()) {
+    const normalizedQuery = filter.query.toLowerCase().trim();
+    materials = materials.filter(
+      (m) =>
+        m.name.toLowerCase().includes(normalizedQuery) ||
+        m.description.toLowerCase().includes(normalizedQuery) ||
+        m.tags?.some((tag) => tag.toLowerCase().includes(normalizedQuery))
+    );
+  }
+
+  // Filter by tags
+  if (filter.tags && filter.tags.length > 0) {
+    materials = materials.filter((m) =>
+      filter.tags!.every((tag) => m.tags?.includes(tag))
+    );
+  }
+
+  // Filter by nuclide count
+  if (filter.minNuclides !== undefined) {
+    materials = materials.filter((m) => m.composition.length >= filter.minNuclides!);
+  }
+  if (filter.maxNuclides !== undefined) {
+    materials = materials.filter((m) => m.composition.length <= filter.maxNuclides!);
+  }
+
+  return materials;
+}
+
+// ============================================================================
+// Conversion Functions
+// ============================================================================
+
+/**
+ * Convert a material to weighted nuclides for cascade input
+ */
+export function materialToWeightedNuclides(material: Material): WeightedNuclide[] {
+  return material.composition.map((comp) => ({
+    nuclideId: comp.nuclideId,
+    proportion: comp.proportion,
+    sourceType: 'material' as const,
+  }));
+}
+
+/**
+ * Build a natural abundance material dynamically from database
+ * Use this for elements not in the predefined list
+ */
+export function buildNaturalElementMaterial(
+  db: Database,
+  elementSymbol: string,
+  elementName?: string
+): Material {
+  const abundances = getNaturalAbundances(db, elementSymbol);
+
+  return {
+    id: `natural-${elementSymbol.toLowerCase()}-dynamic`,
+    name: `Natural ${elementName || elementSymbol}`,
+    category: 'natural-abundance',
+    description: `Natural isotopic composition for ${elementName || elementSymbol}`,
+    composition: abundances.map((a) => ({
+      nuclideId: a.nuclideId,
+      proportion: a.proportion,
+    })),
+    source: 'Database (pcaNCrust)',
+    tags: [elementSymbol.toLowerCase(), 'natural', 'dynamic'],
+  };
+}
+
+/**
+ * Create a material from current weighted fuel selection
+ * (For "Save Current Fuel" functionality)
+ */
+export function createMaterialFromWeightedNuclides(
+  weightedNuclides: WeightedNuclide[],
+  name: string,
+  description: string
+): Omit<Material, 'id' | 'isCustom' | 'createdAt'> {
+  return {
+    name,
+    category: 'custom',
+    description,
+    composition: weightedNuclides.map((n) => ({
+      nuclideId: n.nuclideId,
+      proportion: n.proportion,
+    })),
+    tags: ['custom', 'user-defined'],
+  };
+}
+
+// ============================================================================
+// Material Statistics
+// ============================================================================
+
+/**
+ * Get statistics about the materials catalog
+ */
+export function getMaterialsCatalogStats(): {
+  totalMaterials: number;
+  byCategory: Record<MaterialCategory, number>;
+  customCount: number;
+} {
+  const allMaterials = getAllMaterials();
+  const customMaterials = getCustomMaterials();
+
+  const byCategory: Record<MaterialCategory, number> = {
+    'natural-abundance': 0,
+    'alloy': 0,
+    'compound': 0,
+    'lenr-experiment': 0,
+    'custom': 0,
+  };
+
+  for (const material of allMaterials) {
+    byCategory[material.category]++;
+  }
+
+  return {
+    totalMaterials: allMaterials.length,
+    byCategory,
+    customCount: customMaterials.length,
+  };
+}
+
+/**
+ * Get all unique tags from materials
+ */
+export function getAllMaterialTags(): string[] {
+  const allMaterials = getAllMaterials();
+  const tags = new Set<string>();
+
+  for (const material of allMaterials) {
+    if (material.tags) {
+      for (const tag of material.tags) {
+        tags.add(tag);
+      }
+    }
+  }
+
+  return Array.from(tags).sort();
+}

--- a/src/services/pathwayAnalyzer.ts
+++ b/src/services/pathwayAnalyzer.ts
@@ -6,7 +6,10 @@
  * - Detects feedback loops (products that become inputs)
  * - Calculates frequency, energy, and rarity metrics
  * - Ranks pathways for pattern discovery
+ * - Calculates weighted statistics based on fuel proportions (Issue #96)
  */
+
+import type { WeightedNuclide, WeightedPathwayAnalysis } from '../types';
 
 export interface PathwayAnalysis {
   pathway: string;           // Human-readable: "H-1 + Li-7 → He-4"
@@ -233,5 +236,133 @@ export function getPathwayStats(pathways: PathwayAnalysis[]): PathwayStats {
     avgEnergy,
     mostCommon,
     highestEnergy,
+  };
+}
+
+// ============================================================================
+// Weighted Pathway Analysis (Issue #96)
+// ============================================================================
+
+/**
+ * Calculate weighted pathway statistics based on fuel proportions
+ *
+ * The weighted frequency is calculated as:
+ *   weightedFrequency = frequency * P(input1) * P(input2)
+ *
+ * Where P(inputN) is the proportion of that nuclide in the fuel mixture (0-1).
+ * This represents the probability of both reactants being available for the reaction.
+ *
+ * @param pathways - Base pathway analysis from analyzePathways()
+ * @param weightedFuel - Fuel nuclides with proportions (0-100 scale)
+ * @returns Extended pathway analysis with weighted statistics
+ */
+export function analyzeWeightedPathways(
+  pathways: PathwayAnalysis[],
+  weightedFuel: WeightedNuclide[]
+): WeightedPathwayAnalysis[] {
+  if (pathways.length === 0 || weightedFuel.length === 0) {
+    return [];
+  }
+
+  // Build lookup map for proportions (convert from 0-100 to 0-1 scale)
+  const proportionMap = new Map<string, number>();
+  for (const fuel of weightedFuel) {
+    proportionMap.set(fuel.nuclideId, fuel.proportion / 100);
+  }
+
+  // Calculate weighted statistics for each pathway
+  const weightedPathways: WeightedPathwayAnalysis[] = pathways.map((pathway) => {
+    // Calculate input probability (product of input proportions)
+    // For inputs not in the fuel list, use 1.0 (assumes they're from feedback)
+    const inputContributions: Record<string, number> = {};
+    let inputProbability = 1.0;
+
+    for (const input of pathway.inputs) {
+      const proportion = proportionMap.get(input);
+      if (proportion !== undefined) {
+        inputProbability *= proportion;
+        inputContributions[input] = proportion * 100; // Store as percentage
+      } else {
+        // Input came from a previous reaction (feedback product)
+        // Use 1.0 as it's available from the cascade
+        inputContributions[input] = 100; // 100% available from cascade
+      }
+    }
+
+    // Calculate weighted frequency and energy
+    const weightedFrequency = pathway.frequency * inputProbability;
+    const weightedTotalEnergy = pathway.totalEnergy * inputProbability;
+
+    return {
+      // Copy base pathway fields
+      pathway: pathway.pathway,
+      type: pathway.type,
+      inputs: pathway.inputs,
+      outputs: pathway.outputs,
+      frequency: pathway.frequency,
+      avgEnergy: pathway.avgEnergy,
+      totalEnergy: pathway.totalEnergy,
+      loops: pathway.loops,
+      isFeedback: pathway.isFeedback,
+      rarityScore: pathway.rarityScore,
+
+      // Add weighted statistics
+      weightedFrequency,
+      weightedTotalEnergy,
+      inputContributions,
+    };
+  });
+
+  // Recalculate rarity scores based on weighted frequencies
+  const maxWeightedFrequency = Math.max(...weightedPathways.map((p) => p.weightedFrequency));
+  if (maxWeightedFrequency > 0) {
+    for (const pathway of weightedPathways) {
+      pathway.rarityScore = (pathway.weightedFrequency / maxWeightedFrequency) * 100;
+    }
+  }
+
+  // Sort by weighted frequency (descending)
+  weightedPathways.sort((a, b) => b.weightedFrequency - a.weightedFrequency);
+
+  return weightedPathways;
+}
+
+/**
+ * Get statistics about weighted pathways
+ */
+export interface WeightedPathwayStats extends PathwayStats {
+  weightedTotalReactions: number;
+  weightedAvgFrequency: number;
+  mostCommonWeighted: WeightedPathwayAnalysis | null;
+}
+
+export function getWeightedPathwayStats(
+  pathways: WeightedPathwayAnalysis[]
+): WeightedPathwayStats {
+  const baseStats = getPathwayStats(pathways);
+
+  if (pathways.length === 0) {
+    return {
+      ...baseStats,
+      weightedTotalReactions: 0,
+      weightedAvgFrequency: 0,
+      mostCommonWeighted: null,
+    };
+  }
+
+  const weightedTotalReactions = pathways.reduce((sum, p) => sum + p.weightedFrequency, 0);
+  const weightedAvgFrequency = weightedTotalReactions / pathways.length;
+
+  // Most common weighted pathway
+  const mostCommonWeighted = pathways.reduce(
+    (max, p) => (p.weightedFrequency > max.weightedFrequency ? p : max),
+    pathways[0]
+  );
+
+  return {
+    ...baseStats,
+    weightedTotalReactions,
+    weightedAvgFrequency,
+    mostCommonWeighted,
   };
 }

--- a/src/services/proportionService.ts
+++ b/src/services/proportionService.ts
@@ -1,0 +1,346 @@
+/**
+ * Proportion Service
+ *
+ * Provides functions for working with weighted fuel proportions:
+ * - Format conversion (percentage, atomic ratio, mass ratio)
+ * - Normalization to 100%
+ * - Validation
+ * - Natural abundance lookups
+ */
+
+import type { Database } from 'sql.js';
+import type { WeightedNuclide, ProportionFormat } from '../types';
+import { getNuclidesForElement, parseNuclideNotation } from './isotopeService';
+import { getNuclideBySymbol } from './queryService';
+
+/**
+ * Proportion input as entered by user (before normalization)
+ */
+export interface ProportionInput {
+  nuclideId: string;  // e.g., "Li-7", "Ni-58"
+  value: number;      // Raw value in current format
+}
+
+/**
+ * Validation error for proportion inputs
+ */
+export interface ProportionValidationError {
+  nuclideId?: string;  // Which nuclide has the error (undefined = general error)
+  message: string;
+}
+
+/**
+ * Result of validation
+ */
+export interface ValidationResult {
+  isValid: boolean;
+  errors: ProportionValidationError[];
+}
+
+/**
+ * Validate proportion inputs
+ */
+export function validateProportions(
+  inputs: ProportionInput[],
+  format: ProportionFormat
+): ValidationResult {
+  const errors: ProportionValidationError[] = [];
+
+  // Check for empty inputs
+  if (inputs.length === 0) {
+    errors.push({ message: 'At least one nuclide proportion is required' });
+    return { isValid: false, errors };
+  }
+
+  // Validate each input
+  for (const input of inputs) {
+    // Check nuclide ID format
+    const parsed = parseNuclideNotation(input.nuclideId);
+    if (!parsed) {
+      errors.push({
+        nuclideId: input.nuclideId,
+        message: `Invalid nuclide notation: ${input.nuclideId}`,
+      });
+      continue;
+    }
+
+    // Check value based on format
+    if (typeof input.value !== 'number' || isNaN(input.value)) {
+      errors.push({
+        nuclideId: input.nuclideId,
+        message: 'Value must be a number',
+      });
+      continue;
+    }
+
+    if (input.value < 0) {
+      errors.push({
+        nuclideId: input.nuclideId,
+        message: 'Value cannot be negative',
+      });
+    }
+
+    // Format-specific validation
+    if (format === 'percentage' && input.value > 100) {
+      errors.push({
+        nuclideId: input.nuclideId,
+        message: 'Percentage cannot exceed 100%',
+      });
+    }
+  }
+
+  // Check for duplicate nuclides
+  const nuclideIds = inputs.map((i) => i.nuclideId);
+  const duplicates = nuclideIds.filter((id, idx) => nuclideIds.indexOf(id) !== idx);
+  if (duplicates.length > 0) {
+    errors.push({
+      message: `Duplicate nuclides: ${[...new Set(duplicates)].join(', ')}`,
+    });
+  }
+
+  // Check for zero total (all zeros is invalid)
+  const total = inputs.reduce((sum, i) => sum + (i.value || 0), 0);
+  if (total === 0) {
+    errors.push({ message: 'Total proportion cannot be zero' });
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Normalize proportions to sum to 100%
+ */
+export function normalizeProportions(
+  inputs: ProportionInput[],
+  sourceType: WeightedNuclide['sourceType'] = 'manual'
+): WeightedNuclide[] {
+  const total = inputs.reduce((sum, i) => sum + (i.value || 0), 0);
+
+  if (total === 0) {
+    // If all zeros, distribute equally
+    const equalProportion = 100 / inputs.length;
+    return inputs.map((input) => ({
+      nuclideId: input.nuclideId,
+      proportion: equalProportion,
+      sourceType,
+    }));
+  }
+
+  // Normalize to 100%
+  return inputs.map((input) => ({
+    nuclideId: input.nuclideId,
+    proportion: (input.value / total) * 100,
+    sourceType,
+  }));
+}
+
+/**
+ * Convert atomic ratios to percentages
+ * Example: [{ nuclideId: 'Li-7', value: 3 }, { nuclideId: 'Li-6', value: 1 }]
+ * Returns: [{ nuclideId: 'Li-7', proportion: 75 }, { nuclideId: 'Li-6', proportion: 25 }]
+ */
+export function atomicRatioToPercentage(
+  inputs: ProportionInput[],
+  sourceType: WeightedNuclide['sourceType'] = 'manual'
+): WeightedNuclide[] {
+  // Atomic ratios are just a special case of normalization
+  return normalizeProportions(inputs, sourceType);
+}
+
+/**
+ * Convert mass ratios to percentages using atomic mass units (AMU)
+ * Example: 7g Li-7 + 2g Li-6 → converts to moles, then to atomic ratio
+ */
+export function massRatioToPercentage(
+  db: Database,
+  inputs: ProportionInput[],
+  sourceType: WeightedNuclide['sourceType'] = 'manual'
+): WeightedNuclide[] {
+  // Convert mass to moles for each nuclide
+  const molesInputs: ProportionInput[] = inputs.map((input) => {
+    const parsed = parseNuclideNotation(input.nuclideId);
+    if (!parsed) {
+      // Fall back to using value as-is if we can't parse
+      return input;
+    }
+
+    // Get the nuclide to find its AMU
+    const nuclide = getNuclideBySymbol(db, parsed.element, parsed.massNumber);
+    if (!nuclide || !nuclide.AMU) {
+      // Fall back to using mass number as approximate AMU
+      return {
+        nuclideId: input.nuclideId,
+        value: input.value / parsed.massNumber,
+      };
+    }
+
+    // moles = mass / AMU
+    return {
+      nuclideId: input.nuclideId,
+      value: input.value / nuclide.AMU,
+    };
+  });
+
+  // Now normalize the moles to percentages
+  return normalizeProportions(molesInputs, sourceType);
+}
+
+/**
+ * Convert between proportion formats
+ */
+export function convertFormat(
+  inputs: ProportionInput[],
+  fromFormat: ProportionFormat,
+  toFormat: ProportionFormat,
+  db?: Database
+): WeightedNuclide[] {
+  // If converting to the same format, just normalize
+  if (fromFormat === toFormat || toFormat === 'percentage') {
+    switch (fromFormat) {
+      case 'percentage':
+        return normalizeProportions(inputs);
+      case 'atomic-ratio':
+        return atomicRatioToPercentage(inputs);
+      case 'mass-ratio':
+        if (!db) {
+          throw new Error('Database required for mass ratio conversion');
+        }
+        return massRatioToPercentage(db, inputs);
+    }
+  }
+
+  // For other conversions, first convert to percentage, then convert to target format
+  // But since we only store as percentage internally, we just need to convert to percentage
+  return convertFormat(inputs, fromFormat, 'percentage', db);
+}
+
+/**
+ * Get natural isotopic abundances for an element
+ * Returns WeightedNuclide array with proportions from pcaNCrust database field
+ */
+export function getNaturalAbundances(
+  db: Database,
+  elementSymbol: string
+): WeightedNuclide[] {
+  const nuclides = getNuclidesForElement(db, elementSymbol);
+
+  // Filter to only nuclides with abundance data
+  const withAbundance = nuclides.filter(
+    (n) => n.abundance !== undefined && n.abundance > 0
+  );
+
+  if (withAbundance.length === 0) {
+    // No abundance data - return all nuclides with equal weight
+    return nuclides.map((n) => ({
+      nuclideId: n.notation,
+      proportion: 100 / nuclides.length,
+      sourceType: 'natural' as const,
+    }));
+  }
+
+  // Use pcaNCrust as proportion directly (it's already in percentage)
+  return withAbundance.map((n) => ({
+    nuclideId: n.notation,
+    proportion: n.abundance!,
+    sourceType: 'natural' as const,
+  }));
+}
+
+/**
+ * Create equal proportions from nuclide IDs
+ */
+export function createEqualProportions(
+  nuclideIds: string[],
+  sourceType: WeightedNuclide['sourceType'] = 'manual'
+): WeightedNuclide[] {
+  if (nuclideIds.length === 0) return [];
+
+  const equalProportion = 100 / nuclideIds.length;
+  return nuclideIds.map((nuclideId) => ({
+    nuclideId,
+    proportion: equalProportion,
+    sourceType,
+  }));
+}
+
+/**
+ * Merge weighted nuclides from multiple elements/materials
+ * Re-normalizes after merging
+ */
+export function mergeWeightedNuclides(
+  ...nuclideArrays: WeightedNuclide[][]
+): WeightedNuclide[] {
+  const merged = new Map<string, WeightedNuclide>();
+
+  for (const nuclides of nuclideArrays) {
+    for (const nuclide of nuclides) {
+      if (merged.has(nuclide.nuclideId)) {
+        // Add proportions together
+        const existing = merged.get(nuclide.nuclideId)!;
+        merged.set(nuclide.nuclideId, {
+          ...existing,
+          proportion: existing.proportion + nuclide.proportion,
+        });
+      } else {
+        merged.set(nuclide.nuclideId, { ...nuclide });
+      }
+    }
+  }
+
+  // Convert to array and re-normalize
+  const mergedArray = Array.from(merged.values());
+  const total = mergedArray.reduce((sum, n) => sum + n.proportion, 0);
+
+  if (total === 0) return mergedArray;
+
+  return mergedArray.map((n) => ({
+    ...n,
+    proportion: (n.proportion / total) * 100,
+  }));
+}
+
+/**
+ * Format a proportion for display
+ */
+export function formatProportion(proportion: number): string {
+  if (proportion >= 10) {
+    return `${proportion.toFixed(1)}%`;
+  } else if (proportion >= 1) {
+    return `${proportion.toFixed(2)}%`;
+  } else if (proportion >= 0.01) {
+    return `${proportion.toFixed(3)}%`;
+  } else {
+    return `${proportion.toExponential(2)}%`;
+  }
+}
+
+/**
+ * Get display label for proportion format
+ */
+export function getFormatLabel(format: ProportionFormat): string {
+  switch (format) {
+    case 'percentage':
+      return 'Percentage (%)';
+    case 'atomic-ratio':
+      return 'Atomic Ratio';
+    case 'mass-ratio':
+      return 'Mass Ratio (g)';
+  }
+}
+
+/**
+ * Get help text for proportion format
+ */
+export function getFormatHelpText(format: ProportionFormat): string {
+  switch (format) {
+    case 'percentage':
+      return 'Enter percentages (0-100). Values will be normalized to 100%.';
+    case 'atomic-ratio':
+      return 'Enter atomic ratios (e.g., 3:1 becomes 75%:25%).';
+    case 'mass-ratio':
+      return 'Enter masses in grams. Converted to moles using atomic mass.';
+  }
+}

--- a/src/services/proportionService.ts
+++ b/src/services/proportionService.ts
@@ -304,6 +304,7 @@ export function mergeWeightedNuclides(
 
 /**
  * Format a proportion for display
+ * Uses consistent decimal precision without scientific notation
  */
 export function formatProportion(proportion: number): string {
   if (proportion >= 10) {
@@ -312,8 +313,13 @@ export function formatProportion(proportion: number): string {
     return `${proportion.toFixed(2)}%`;
   } else if (proportion >= 0.01) {
     return `${proportion.toFixed(3)}%`;
+  } else if (proportion >= 0.001) {
+    return `${proportion.toFixed(4)}%`;
+  } else if (proportion > 0) {
+    // For very small values, show enough precision to see the value
+    return `${proportion.toFixed(5)}%`;
   } else {
-    return `${proportion.toExponential(2)}%`;
+    return '0%';
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -241,6 +241,9 @@ export interface CascadeResults {
   loopsExecuted: number;                           // Actual loops run (may be < maxLoops)
   executionTime: number;                           // Time in milliseconds
   terminationReason: 'max_loops' | 'no_new_products' | 'max_nuclides'; // Why cascade stopped
+  // Weighted mode fields (Issue #96)
+  weightedFuel?: WeightedNuclide[];                // Fuel proportions used (if weighted mode)
+  useWeightedMode?: boolean;                       // Whether weighted analysis should be applied
 }
 
 // Decay chain types for multi-generation radioactive decay visualization
@@ -323,6 +326,11 @@ export interface CascadePageState {
   // Fuel nuclides
   fuelNuclides: string[];
 
+  // Weighted fuel proportions (Issue #96)
+  weightedFuel?: WeightedNuclide[];
+  proportionFormat?: ProportionFormat;
+  useWeightedMode?: boolean;
+
   // Simulation results (optional - only present after running simulation)
   results?: CascadeResults;
 
@@ -336,4 +344,141 @@ export interface AllQueryStates {
   twotwo?: QueryPageState;
   cascade?: CascadePageState;
   version?: number;  // For future migration if state structure changes
+}
+
+// ============================================================================
+// Weighted Fuel Proportions Types (Issue #96)
+// ============================================================================
+
+/**
+ * How the proportion was set - manual input, from a material, or natural abundance
+ */
+export type ProportionSourceType = 'manual' | 'material' | 'natural';
+
+/**
+ * Input format for specifying proportions
+ */
+export type ProportionFormat = 'percentage' | 'atomic-ratio' | 'mass-ratio';
+
+/**
+ * A fuel nuclide with its proportion in the mixture
+ */
+export interface WeightedNuclide {
+  nuclideId: string;                    // e.g., "Li-7", "Ni-58", "H-1"
+  proportion: number;                   // 0-100 percentage (normalized internally)
+  sourceType?: ProportionSourceType;    // How this proportion was set
+}
+
+/**
+ * Extended cascade parameters with weighted fuel support
+ */
+export interface CascadeParametersV2 extends CascadeParameters {
+  weightedFuel?: WeightedNuclide[];     // Proportional fuel input
+  proportionFormat?: ProportionFormat;  // How proportions were entered
+  useWeightedMode?: boolean;            // Toggle weighted vs equal-weight mode
+  monteCarloIterations?: number;        // For Monte Carlo sampling (default: 1000)
+}
+
+/**
+ * Pathway analysis with weighted statistics
+ * Mirrors PathwayAnalysis from pathwayAnalyzer.ts with additional weighted fields
+ */
+export interface WeightedPathwayAnalysis {
+  // Base pathway fields (mirrors PathwayAnalysis)
+  pathway: string;                      // Human-readable: "H-1 + Li-7 → He-4"
+  type: 'fusion' | 'twotwo';
+  inputs: string[];
+  outputs: string[];
+  frequency: number;                    // Raw count of occurrences
+  avgEnergy: number;                    // Average MeV per occurrence
+  totalEnergy: number;                  // Total MeV across all occurrences
+  loops: number[];                      // Which loop numbers this pathway appears in
+  isFeedback: boolean;                  // Does an output become an input later?
+  rarityScore: number;                  // 0-100, where 100 = most common pathway
+
+  // Weighted statistics
+  weightedFrequency: number;            // Frequency adjusted by input proportions
+  weightedTotalEnergy: number;          // Energy weighted by proportions
+  inputContributions: Record<string, number>;  // Which fuel nuclides contributed and by how much
+}
+
+/**
+ * Monte Carlo sampling statistics
+ */
+export interface SamplingStats {
+  iterations: number;                   // Number of Monte Carlo iterations run
+  convergenceMetric: number;            // Statistical convergence measure (0-1)
+}
+
+/**
+ * Extended cascade results with weighted pathway analysis
+ */
+export interface CascadeResultsV2 extends CascadeResults {
+  weightedPathways?: WeightedPathwayAnalysis[];  // Pathway analysis with weighted stats
+  proportionNormalized?: WeightedNuclide[];      // Actual proportions used (normalized)
+  samplingStats?: SamplingStats;                 // Monte Carlo sampling statistics
+}
+
+// ============================================================================
+// Materials Catalog Types (Issue #96)
+// ============================================================================
+
+/**
+ * Category of material in the catalog
+ */
+export type MaterialCategory =
+  | 'natural-abundance'   // Natural isotopic abundances for an element
+  | 'alloy'               // Metal alloys (stainless steel, bronze, etc.)
+  | 'compound'            // Chemical compounds (LiAlH4, NaBH4, etc.)
+  | 'lenr-experiment'     // Historical LENR experiment fuel compositions
+  | 'custom';             // User-defined custom mixtures
+
+/**
+ * A single nuclide component in a material composition
+ */
+export interface MaterialComposition {
+  nuclideId: string;                    // e.g., "Li-7", "Fe-56"
+  proportion: number;                   // Percentage (0-100)
+}
+
+/**
+ * A material definition for the catalog
+ */
+export interface Material {
+  id: string;                           // Unique identifier
+  name: string;                         // Display name (e.g., "Natural Lithium")
+  category: MaterialCategory;
+  description: string;                  // Brief description
+  composition: MaterialComposition[];   // Nuclide proportions
+  source?: string;                      // Citation or reference URL
+  isCustom?: boolean;                   // True if user-created
+  createdAt?: number;                   // Timestamp for custom materials
+  tags?: string[];                      // Search tags
+}
+
+/**
+ * Extended material type for historical LENR experiments
+ */
+export interface LENRExperiment extends Material {
+  researcher: string;                   // Primary researcher name
+  year?: number;                        // Year of experiment
+  citation?: string;                    // Full citation or DOI
+  experimentType?: string;              // Type of experiment (e.g., "Ni-H", "Pd-D")
+}
+
+/**
+ * Extended cascade page state with weighted fuel support
+ */
+export interface CascadePageStateV2 extends CascadePageState {
+  // Weighted fuel proportions
+  weightedFuel?: WeightedNuclide[];
+  proportionFormat?: ProportionFormat;
+  useWeightedMode?: boolean;
+  monteCarloIterations?: number;
+
+  // Materials catalog state
+  selectedMaterialId?: string;          // Currently selected material
+
+  // Extended results
+  results?: CascadeResultsV2;
 }

--- a/src/workers/cascadeWorker.ts
+++ b/src/workers/cascadeWorker.ts
@@ -6,13 +6,13 @@
  */
 
 import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
-import type { CascadeParameters, CascadeResults } from '../types';
+import type { CascadeParameters, CascadeParametersV2, CascadeResults } from '../types';
 import { applyFeedbackRules, shouldAllowDimerReaction } from '../services/cascadeFeedbackRules';
 
 // Message types
 export interface CascadeWorkerRequest {
   type: 'run';
-  params: CascadeParameters;
+  params: CascadeParameters | CascadeParametersV2;
   dbBuffer: ArrayBuffer;
 }
 
@@ -97,8 +97,9 @@ function buildNuclideId(E: string, A: number): string {
 
 /**
  * Run cascade simulation with progress updates
+ * Supports weighted mode via CascadeParametersV2
  */
-async function runCascadeWithProgress(params: CascadeParameters): Promise<CascadeResults> {
+async function runCascadeWithProgress(params: CascadeParameters | CascadeParametersV2): Promise<CascadeResults> {
   if (!db) {
     throw new Error('Database not initialized');
   }
@@ -311,6 +312,11 @@ async function runCascadeWithProgress(params: CascadeParameters): Promise<Cascad
     newReactionsCount: -3, // Special value for serialization
   } as CascadeProgressMessage);
 
+  // Extract weighted mode fields if available (Issue #96)
+  const v2Params = params as CascadeParametersV2;
+  const weightedFuel = v2Params.weightedFuel;
+  const useWeightedMode = v2Params.useWeightedMode ?? false;
+
   return {
     reactions: allReactions,
     productDistribution,
@@ -320,6 +326,8 @@ async function runCascadeWithProgress(params: CascadeParameters): Promise<Cascad
     loopsExecuted: loopCount,
     executionTime,
     terminationReason,
+    // Include weighted configuration in results for downstream analysis
+    ...(useWeightedMode && weightedFuel ? { weightedFuel, useWeightedMode } : {}),
   };
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -138,6 +138,9 @@ export default defineConfig({
     'import.meta.env.VITE_APP_VERSION': JSON.stringify(getVersion()),
     'import.meta.env.VITE_BUILD_TIME': JSON.stringify(getBuildTime()),
   },
+  server: {
+    host: '0.0.0.0',
+  },
   build: {
     // Generate source maps for production builds
     // This helps Sentry provide readable stack traces


### PR DESCRIPTION
## Summary

- Implement weighted fuel proportions for cascade analysis, allowing users to specify relative abundances of input nuclides
- Add materials catalog with predefined materials (e.g., natural isotopic abundances, specific alloys)
- Add blend mode for combining multiple materials into custom fuel mixtures
- Fix dev server to bind to all interfaces for containerization support

## Changes

- **ProportionInput component**: UI for specifying nuclide proportions with validation
- **MaterialsCatalog component**: Browsable catalog of predefined materials
- **materialsService**: Service for managing material definitions and blending
- **proportionService**: Service for proportion calculations and normalization
- **pathwayAnalyzer**: Enhanced analysis accounting for weighted inputs
- **CascadeSankeyDiagram**: Updated to visualize weighted flows
- **E2E tests**: Comprehensive tests for weighted cascade functionality

## Test plan

- [ ] Verify proportion inputs accept valid percentages and normalize correctly
- [ ] Test material selection from catalog applies correct isotope ratios
- [ ] Test blend mode combines multiple materials properly
- [ ] Verify Sankey diagram reflects weighted proportions visually
- [ ] Run E2E tests: `npm run test:e2e -- weighted-cascade`