### PR TITLE
Add URL deep-linking for Cascades and Muller Resonance

### DIFF
--- a/src/pages/CascadesAll.tsx
+++ b/src/pages/CascadesAll.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
 import { Play, Settings, AlertCircle, CheckCircle, XCircle, Loader2, Download, Scale, BookOpen } from 'lucide-react'
 import { useDatabase } from '../contexts/DatabaseContext'
 import { useQueryState } from '../contexts/QueryStateContext'
@@ -12,42 +13,132 @@ import MaterialsCatalog from '../components/MaterialsCatalog'
 import DatabaseLoadingCard from '../components/DatabaseLoadingCard'
 import { getAllElements } from '../services/queryService'
 import { createEqualProportions } from '../services/proportionService'
+import { getMaterialById } from '../constants/materials'
 import type { CascadeResults, Element, WeightedNuclide, ProportionFormat } from '../types'
+
+// Parse URL search params into cascade state (returns null fields when param is absent)
+function parseUrlParams(searchParams: URLSearchParams) {
+  const has = searchParams.toString().length > 0
+  if (!has) return null
+
+  const str = (key: string) => searchParams.get(key)
+  const num = (key: string) => { const v = searchParams.get(key); return v !== null ? parseFloat(v) : undefined }
+  const bool = (key: string) => { const v = searchParams.get(key); return v !== null ? v === 'true' : undefined }
+  const list = (key: string) => { const v = searchParams.get(key); return v ? v.split(',') : undefined }
+
+  // Resolve ?material= to fuel nuclides + weighted mode
+  const materialId = str('material')
+  let materialFuel: WeightedNuclide[] | undefined
+  let materialNuclides: string[] | undefined
+  if (materialId) {
+    const mat = getMaterialById(materialId)
+    if (mat) {
+      materialFuel = mat.composition.map(c => ({
+        nuclideId: c.nuclideId,
+        proportion: c.proportion,
+        sourceType: 'material' as const,
+      }))
+      materialNuclides = mat.composition.map(c => c.nuclideId)
+    }
+  }
+
+  return {
+    fuel: list('fuel') ?? materialNuclides,
+    temperature: num('temp'),
+    minFusionMeV: num('minFusionMeV'),
+    minTwoToTwoMeV: num('minTwoToTwoMeV'),
+    maxLoops: num('maxLoops'),
+    maxNuclides: num('maxNuclides'),
+    feedbackBosons: bool('feedbackBosons'),
+    feedbackFermions: bool('feedbackFermions'),
+    allowDimers: bool('allowDimers'),
+    excludeMelted: bool('excludeMelted'),
+    excludeBoiledOff: bool('excludeBoiledOff'),
+    materialFuel,
+    useWeightedMode: materialFuel ? true : undefined,
+  }
+}
+
+const DEFAULT_PARAMS = {
+  temperature: 2400,
+  minFusionMeV: 1.0,
+  minTwoToTwoMeV: 1.0,
+  maxNuclides: 5000,
+  maxLoops: 25,
+  feedbackBosons: true,
+  feedbackFermions: true,
+  allowDimers: true,
+  excludeMelted: false,
+  excludeBoiledOff: true,
+}
+
+const DEFAULT_FUEL = ['H-1', 'Li-7', 'Al-27', 'N-14', 'Ni-58', 'Ni-60', 'Ni-62', 'B-10', 'B-11']
 
 export default function CascadesAll() {
   const { t } = useTranslation()
   const { db, isLoading: dbLoading, error: dbError, downloadProgress } = useDatabase()
   const { getCascadeState, updateCascadeState } = useQueryState()
   const { runCascade, cancelCascade, progress, isRunning, error: workerError } = useCascadeWorker()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const hasUrlParams = useRef(searchParams.toString().length > 0)
+  const isInitialMount = useRef(true)
   const [hasRestoredFromContext, setHasRestoredFromContext] = useState(false)
 
-  const [params, setParams] = useState({
-    temperature: 2400,
-    minFusionMeV: 1.0,
-    minTwoToTwoMeV: 1.0,
-    maxNuclides: 5000,
-    maxLoops: 25,
-    feedbackBosons: true,
-    feedbackFermions: true,
-    allowDimers: true,
-    excludeMelted: false,
-    excludeBoiledOff: true,
+  // Parse URL params once on mount
+  const urlState = useRef(parseUrlParams(searchParams))
+
+  const [params, setParams] = useState(() => {
+    const u = urlState.current
+    if (!u) return { ...DEFAULT_PARAMS }
+    return {
+      temperature: u.temperature ?? DEFAULT_PARAMS.temperature,
+      minFusionMeV: u.minFusionMeV ?? DEFAULT_PARAMS.minFusionMeV,
+      minTwoToTwoMeV: u.minTwoToTwoMeV ?? DEFAULT_PARAMS.minTwoToTwoMeV,
+      maxNuclides: u.maxNuclides ?? DEFAULT_PARAMS.maxNuclides,
+      maxLoops: u.maxLoops ?? DEFAULT_PARAMS.maxLoops,
+      feedbackBosons: u.feedbackBosons ?? DEFAULT_PARAMS.feedbackBosons,
+      feedbackFermions: u.feedbackFermions ?? DEFAULT_PARAMS.feedbackFermions,
+      allowDimers: u.allowDimers ?? DEFAULT_PARAMS.allowDimers,
+      excludeMelted: u.excludeMelted ?? DEFAULT_PARAMS.excludeMelted,
+      excludeBoiledOff: u.excludeBoiledOff ?? DEFAULT_PARAMS.excludeBoiledOff,
+    }
   })
 
   // Local state for sliders during dragging (prevents performance issues)
-  const [sliderMaxNuclides, setSliderMaxNuclides] = useState(5000)
-  const [sliderMaxLoops, setSliderMaxLoops] = useState(25)
+  const [sliderMaxNuclides, setSliderMaxNuclides] = useState(() => urlState.current?.maxNuclides ?? DEFAULT_PARAMS.maxNuclides)
+  const [sliderMaxLoops, setSliderMaxLoops] = useState(() => urlState.current?.maxLoops ?? DEFAULT_PARAMS.maxLoops)
 
   const [availableElements, setAvailableElements] = useState<Element[]>([])
-  const [fuelNuclides, setFuelNuclides] = useState<string[]>(['H-1', 'Li-7', 'Al-27', 'N-14', 'Ni-58', 'Ni-60', 'Ni-62', 'B-10', 'B-11'])
+  const [fuelNuclides, setFuelNuclides] = useState<string[]>(() => urlState.current?.fuel ?? DEFAULT_FUEL)
   const [results, setResults] = useState<CascadeResults | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   // Weighted mode state (Issue #96)
-  const [useWeightedMode, setUseWeightedMode] = useState(false)
-  const [weightedFuel, setWeightedFuel] = useState<WeightedNuclide[]>([])
+  const [useWeightedMode, setUseWeightedMode] = useState(() => urlState.current?.useWeightedMode ?? false)
+  const [weightedFuel, setWeightedFuel] = useState<WeightedNuclide[]>(() => urlState.current?.materialFuel ?? [])
   const [proportionFormat, setProportionFormat] = useState<ProportionFormat>('percentage')
   const [showMaterialsCatalog, setShowMaterialsCatalog] = useState(false)
+
+  // Sync state → URL params (skip initial mount)
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+      return
+    }
+    const p = new URLSearchParams()
+    if (fuelNuclides.join(',') !== DEFAULT_FUEL.join(',')) p.set('fuel', fuelNuclides.join(','))
+    if (params.temperature !== DEFAULT_PARAMS.temperature) p.set('temp', String(params.temperature))
+    if (params.minFusionMeV !== DEFAULT_PARAMS.minFusionMeV) p.set('minFusionMeV', String(params.minFusionMeV))
+    if (params.minTwoToTwoMeV !== DEFAULT_PARAMS.minTwoToTwoMeV) p.set('minTwoToTwoMeV', String(params.minTwoToTwoMeV))
+    if (params.maxLoops !== DEFAULT_PARAMS.maxLoops) p.set('maxLoops', String(params.maxLoops))
+    if (params.maxNuclides !== DEFAULT_PARAMS.maxNuclides) p.set('maxNuclides', String(params.maxNuclides))
+    if (params.feedbackBosons !== DEFAULT_PARAMS.feedbackBosons) p.set('feedbackBosons', String(params.feedbackBosons))
+    if (params.feedbackFermions !== DEFAULT_PARAMS.feedbackFermions) p.set('feedbackFermions', String(params.feedbackFermions))
+    if (params.allowDimers !== DEFAULT_PARAMS.allowDimers) p.set('allowDimers', String(params.allowDimers))
+    if (params.excludeMelted !== DEFAULT_PARAMS.excludeMelted) p.set('excludeMelted', String(params.excludeMelted))
+    if (params.excludeBoiledOff !== DEFAULT_PARAMS.excludeBoiledOff) p.set('excludeBoiledOff', String(params.excludeBoiledOff))
+    setSearchParams(p, { replace: true })
+  }, [fuelNuclides, params, setSearchParams])
 
   // Load available elements and restore state when database is ready
   useEffect(() => {
@@ -55,10 +146,10 @@ export default function CascadesAll() {
       const elements = getAllElements(db)
       setAvailableElements(elements)
 
-      // Restore state from context if not already done
+      // Restore state from context if not already done (skip if URL params provided)
       if (!hasRestoredFromContext) {
         const savedState = getCascadeState()
-        if (savedState) {
+        if (savedState && !hasUrlParams.current) {
           setParams({
             temperature: savedState.temperature,
             minFusionMeV: savedState.minFusionMeV,
@@ -216,21 +307,10 @@ export default function CascadesAll() {
   }
 
   const handleReset = () => {
-    setParams({
-      temperature: 2400,
-      minFusionMeV: 1.0,
-      minTwoToTwoMeV: 1.0,
-      maxNuclides: 5000,
-      maxLoops: 25,
-      feedbackBosons: true,
-      feedbackFermions: true,
-      allowDimers: true,
-      excludeMelted: false,
-      excludeBoiledOff: true,
-    })
-    setSliderMaxNuclides(5000)
-    setSliderMaxLoops(25)
-    setFuelNuclides(['H-1', 'Li-7', 'Al-27', 'N-14', 'Ni-58', 'Ni-60', 'Ni-62', 'B-10', 'B-11'])
+    setParams({ ...DEFAULT_PARAMS })
+    setSliderMaxNuclides(DEFAULT_PARAMS.maxNuclides)
+    setSliderMaxLoops(DEFAULT_PARAMS.maxLoops)
+    setFuelNuclides([...DEFAULT_FUEL])
     setResults(null)
     setError(null)
     // Reset weighted mode state

--- a/src/pages/CascadesAll.tsx
+++ b/src/pages/CascadesAll.tsx
@@ -22,7 +22,7 @@ function parseUrlParams(searchParams: URLSearchParams) {
   if (!has) return null
 
   const str = (key: string) => searchParams.get(key)
-  const num = (key: string) => { const v = searchParams.get(key); return v !== null ? parseFloat(v) : undefined }
+  const num = (key: string) => { const v = searchParams.get(key); if (v === null) return undefined; const n = parseFloat(v); return isNaN(n) ? undefined : n }
   const bool = (key: string) => { const v = searchParams.get(key); return v !== null ? v === 'true' : undefined }
   const list = (key: string) => { const v = searchParams.get(key); return v ? v.split(',') : undefined }
 

--- a/src/pages/MullerResonance.tsx
+++ b/src/pages/MullerResonance.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
 import { useDatabase } from '../contexts/DatabaseContext'
@@ -27,18 +27,32 @@ type SortDirection = 'asc' | 'desc'
 export default function MullerResonance() {
   const { t } = useTranslation()
   const { db, isLoading: dbLoading, downloadProgress } = useDatabase()
-  const [searchParams] = useSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const isInitialMount = useRef(true)
   const [elements, setElements] = useState<Element[]>([])
-  const [selectedElement, setSelectedElement] = useState<string | null>(null)
-  const [threshold, setThreshold] = useState(5.0)
+
+  // Initialize state from URL params (read once on mount)
+  const [selectedElement, setSelectedElement] = useState<string | null>(
+    searchParams.get('element') || null
+  )
+  const [threshold, setThreshold] = useState(() => {
+    const p = searchParams.get('threshold')
+    return p ? parseFloat(p) : 5.0
+  })
 
   // Tab state
   const [activeTab, setActiveTab] = useState(searchParams.get('tab') || 'resonance')
 
   // NAE UI state
-  const [naeFilter, setNaeFilter] = useState(false)
-  const [naeSortColumn, setNaeSortColumn] = useState<SortColumn>('naeScore')
-  const [naeSortDirection, setNaeSortDirection] = useState<SortDirection>('asc')
+  const [naeFilter, setNaeFilter] = useState(searchParams.get('naeFilter') === 'true')
+  const [naeSortColumn, setNaeSortColumn] = useState<SortColumn>(() => {
+    const p = searchParams.get('sort') as SortColumn | null
+    return p && ['element', 'naeScore', 'wavelength', 'deuterium', 'phonon', 'reactions', 'lenr'].includes(p) ? p : 'naeScore'
+  })
+  const [naeSortDirection, setNaeSortDirection] = useState<SortDirection>(() => {
+    const p = searchParams.get('dir') as SortDirection | null
+    return p === 'desc' ? 'desc' : 'asc'
+  })
   const [expandedRow, setExpandedRow] = useState<number | null>(null)
 
   // Worker handles all heavy computation off the main thread
@@ -59,6 +73,22 @@ export default function MullerResonance() {
     { id: 'resonance', label: t('mullerResonance.tabs.resonancePairs') },
     { id: 'nae', label: t('mullerResonance.tabs.naePredictions') },
   ], [t])
+
+  // Sync state → URL params (skip initial mount to avoid replacing URL on load)
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+      return
+    }
+    const params = new URLSearchParams()
+    if (activeTab !== 'resonance') params.set('tab', activeTab)
+    if (selectedElement) params.set('element', selectedElement)
+    if (threshold !== 5.0) params.set('threshold', String(threshold))
+    if (naeFilter) params.set('naeFilter', 'true')
+    if (activeTab === 'nae' && naeSortColumn !== 'naeScore') params.set('sort', naeSortColumn)
+    if (activeTab === 'nae' && naeSortDirection !== 'asc') params.set('dir', naeSortDirection)
+    setSearchParams(params, { replace: true })
+  }, [activeTab, selectedElement, threshold, naeFilter, naeSortColumn, naeSortDirection, setSearchParams])
 
   // Load elements and initialize worker
   useEffect(() => {

--- a/src/pages/MullerResonance.tsx
+++ b/src/pages/MullerResonance.tsx
@@ -37,7 +37,9 @@ export default function MullerResonance() {
   )
   const [threshold, setThreshold] = useState(() => {
     const p = searchParams.get('threshold')
-    return p ? parseFloat(p) : 5.0
+    if (!p) return 5.0
+    const n = parseFloat(p)
+    return isNaN(n) ? 5.0 : n
   })
 
   // Tab state


### PR DESCRIPTION
## Summary

- **Cascades**: Full URL param support — `?fuel=H-1,Li-7,Ni-58`, `?material=parkhomov-2014` (resolves preset + enables weighted mode), `?temp=`, `?maxLoops=`, and all boolean toggles. URL params take priority over QueryStateContext restore.
- **Muller Resonance**: Added `?element=`, `?threshold=`, `?naeFilter=`, `?sort=`, `?dir=` alongside existing `?tab=`. Enables deep-linking to specific element analyses and NAE configurations.
- Both pages only serialize non-default values to keep URLs clean, and use `replace: true` to avoid cluttering browser history.

Enables the follow-up PR to add Help page example links for Cascades and Muller Resonance.

## Test plan

- [x] Build passes
- [x] All tests pass (1090/1090, 1 pre-existing timeout unrelated)
- [ ] Navigate to `/cascades?material=parkhomov-2014` — should load Parkhomov Ni-LiAlH4 preset with weighted mode
- [ ] Navigate to `/cascades?fuel=H-1,Ni-58&temp=3000` — should set fuel and temperature
- [ ] Navigate to `/muller-resonance?element=Cu&threshold=1` — should select Copper with 1% threshold
- [ ] Navigate to `/muller-resonance?tab=nae&naeFilter=true` — should show NAE tab filtered
- [ ] Verify changing state updates the URL bar in real-time
- [ ] Verify browser back/forward works

🤖 Generated with [Claude Code](https://claude.com/claude-code)