### PR TITLE
feat: diversify Help page examples across all page types (clean rebase of #164)

### DIFF
--- a/e2e/tests/help-page.spec.ts
+++ b/e2e/tests/help-page.spec.ts
@@ -19,7 +19,7 @@ test.describe('Help Page', () => {
 
   test('should display example query cards with names and descriptions', async ({ page }) => {
     await expect(page.getByText('Hydrogen-Lithium Fusion')).toBeVisible();
-    await expect(page.getByText('Deuterium-Deuterium Fusion')).toBeVisible();
+    await expect(page.getByText('Nickel-Hydrogen Fusion')).toBeVisible();
     await expect(page.getByText('Uranium Fission Pathways')).toBeVisible();
   });
 

--- a/src/data/exampleQueries.test.ts
+++ b/src/data/exampleQueries.test.ts
@@ -10,7 +10,7 @@ describe('exampleQueries', () => {
     EXAMPLE_QUERIES.forEach(query => {
       expect(query.name).toBeTruthy();
       expect(query.description).toBeTruthy();
-      expect(['fusion', 'fission', 'twotwo']).toContain(query.queryType);
+      expect(['fusion', 'fission', 'twotwo', 'element-data', 'cascades', 'muller-resonance']).toContain(query.queryType);
       expect(query.filter).toBeDefined();
     });
   });
@@ -30,16 +30,35 @@ describe('exampleQueries', () => {
     expect(twotwo.length).toBeGreaterThan(0);
   });
 
+  it('includes element-data examples', () => {
+    const elementData = EXAMPLE_QUERIES.filter(q => q.queryType === 'element-data');
+    expect(elementData.length).toBeGreaterThan(0);
+    elementData.forEach(q => {
+      expect(q.elementZ).toBeDefined();
+    });
+  });
+
+  it('includes cascades example', () => {
+    const cascades = EXAMPLE_QUERIES.filter(q => q.queryType === 'cascades');
+    expect(cascades.length).toBeGreaterThan(0);
+    cascades.forEach(q => {
+      expect(q.materialId).toBeTruthy();
+    });
+  });
+
+  it('includes muller-resonance example', () => {
+    const muller = EXAMPLE_QUERIES.filter(q => q.queryType === 'muller-resonance');
+    expect(muller.length).toBeGreaterThan(0);
+    muller.forEach(q => {
+      expect(q.mullerParams).toBeDefined();
+    });
+  });
+
   it('includes H-Li fusion example', () => {
     const hli = EXAMPLE_QUERIES.find(q =>
       q.element1List?.includes('H') && q.element2List?.includes('Li')
     );
     expect(hli).toBeDefined();
     expect(hli!.queryType).toBe('fusion');
-  });
-
-  it('includes high-energy fusion example', () => {
-    const highE = EXAMPLE_QUERIES.find(q => q.filter.minMeV && q.filter.minMeV >= 10);
-    expect(highE).toBeDefined();
   });
 });

--- a/src/data/exampleQueries.ts
+++ b/src/data/exampleQueries.ts
@@ -3,29 +3,28 @@ import { QueryFilter } from '../types';
 export interface ExampleQuery {
   name: string;
   description: string;
-  queryType: 'fusion' | 'fission' | 'twotwo';
+  queryType: 'fusion' | 'fission' | 'twotwo' | 'element-data' | 'cascades' | 'muller-resonance';
   filter: QueryFilter;
   element1List?: string[];
   element2List?: string[];
   outputElementList?: string[];
+  /** For element-data links: Z and optional A */
+  elementZ?: number;
+  elementA?: number;
+  /** For cascades links: material preset ID or fuel list */
+  materialId?: string;
+  /** For muller-resonance links: URL params */
+  mullerParams?: Record<string, string>;
 }
 
 export const EXAMPLE_QUERIES: ExampleQuery[] = [
-  // Fusion examples
+  // Fusion examples (2)
   {
     name: 'Hydrogen-Lithium Fusion',
     description: 'Classic LENR reaction pathway. H + Li fusion produces beryllium and helium isotopes with significant energy release.',
     queryType: 'fusion',
     element1List: ['H'],
     element2List: ['Li'],
-    filter: {},
-  },
-  {
-    name: 'Deuterium-Deuterium Fusion',
-    description: 'D + D reactions are central to fusion research. Produces He-3 or tritium depending on the pathway.',
-    queryType: 'fusion',
-    element1List: ['D'],
-    element2List: ['D'],
     filter: {},
   },
   {
@@ -36,25 +35,13 @@ export const EXAMPLE_QUERIES: ExampleQuery[] = [
     element2List: ['Ni'],
     filter: {},
   },
-  {
-    name: 'High-Energy Fusion (>10 MeV)',
-    description: 'Find fusion reactions releasing more than 10 MeV of energy. Shows the most energetic transmutation pathways.',
-    queryType: 'fusion',
-    filter: { minMeV: 10 },
-  },
 
-  // Fission examples
+  // Fission examples (2)
   {
     name: 'Uranium Fission Pathways',
     description: 'All fission pathways from uranium isotopes. Shows the diverse product spectrum of uranium splitting.',
     queryType: 'fission',
     filter: { elements: ['U'] },
-  },
-  {
-    name: 'Iron Fission',
-    description: 'Exothermic fission pathways from iron isotopes. Iron-56 has near-peak binding energy per nucleon, so fewer exothermic fission pathways exist compared to heavier elements.',
-    queryType: 'fission',
-    filter: { elements: ['Fe'] },
   },
   {
     name: 'Palladium Fission',
@@ -63,15 +50,7 @@ export const EXAMPLE_QUERIES: ExampleQuery[] = [
     filter: { elements: ['Pd'] },
   },
 
-  // Two-to-Two examples
-  {
-    name: 'Deuterium-Nickel Reactions',
-    description: 'D + Ni two-to-two reactions. The default query showing deuterium-based transmutations with nickel, lithium, aluminum, boron, and nitrogen.',
-    queryType: 'twotwo',
-    element1List: ['D'],
-    element2List: ['Ni', 'Li', 'Al', 'B', 'N'],
-    filter: {},
-  },
+  // Two-to-Two examples (2)
   {
     name: 'Proton-Boron Reactions',
     description: 'H + B-11 produces three alpha particles in the aneutronic fusion reaction (p + B-11 → 3α), considered ideal for clean energy.',
@@ -81,11 +60,47 @@ export const EXAMPLE_QUERIES: ExampleQuery[] = [
     filter: {},
   },
   {
-    name: 'Lithium-Lithium Reactions',
-    description: 'Li + Li two-to-two reactions. Lithium is a key element in LENR research due to its low atomic number and high reactivity.',
+    name: 'Deuterium-Nickel Reactions',
+    description: 'D + Ni two-to-two reactions showing deuterium-based transmutations with nickel, lithium, aluminum, boron, and nitrogen.',
     queryType: 'twotwo',
-    element1List: ['Li'],
-    element2List: ['Li'],
+    element1List: ['D'],
+    element2List: ['Ni', 'Li', 'Al', 'B', 'N'],
+    filter: {},
+  },
+
+  // Element Data examples (2)
+  {
+    name: 'Uranium-238 Decay Chain',
+    description: 'The most famous natural decay series (4n+2). Trace 14 steps from U-238 through radium and radon down to stable Pb-206.',
+    queryType: 'element-data',
+    elementZ: 92,
+    elementA: 238,
+    filter: {},
+  },
+  {
+    name: 'Iron-56 — Peak Binding Energy',
+    description: 'Fe-56 has the highest binding energy per nucleon of any nuclide, making it the endpoint of stellar nucleosynthesis.',
+    queryType: 'element-data',
+    elementZ: 26,
+    elementA: 56,
+    filter: {},
+  },
+
+  // Muller Resonance example (1)
+  {
+    name: 'Palladium NAE Analysis',
+    description: 'Explore palladium\'s nuclear active environment predictions — central to Fleischmann-Pons deuterium loading experiments.',
+    queryType: 'muller-resonance',
+    mullerParams: { tab: 'nae', element: 'Pd', naeFilter: 'true' },
+    filter: {},
+  },
+
+  // Cascades example (1)
+  {
+    name: 'Parkhomov Ni-LiAlH₄ Cascade',
+    description: 'Simulate the 2014 Parkhomov replication of the Rossi reactor using natural nickel with lithium aluminum hydride fuel.',
+    queryType: 'cascades',
+    materialId: 'parkhomov-2014',
     filter: {},
   },
 ];

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -27,16 +27,47 @@ export default function Help() {
 
   const handleTryQuery = (query: ExampleQuery) => {
     const params = new URLSearchParams();
-    if (query.element1List?.length) params.set('e1', query.element1List.join(','));
-    if (query.element2List?.length) params.set('e2', query.element2List.join(','));
-    if (query.outputElementList?.length) params.set('e', query.outputElementList.join(','));
-    if (query.filter.elements?.length) params.set('e', query.filter.elements.join(','));
-    if (query.filter.minMeV !== undefined) params.set('minMeV', String(query.filter.minMeV));
-    if (query.filter.maxMeV !== undefined) params.set('maxMeV', String(query.filter.maxMeV));
 
-    const routes = { fusion: '/fusion', fission: '/fission', twotwo: '/twotwo' };
-    const search = params.toString();
-    navigate(`${routes[query.queryType]}${search ? `?${search}` : ''}`);
+    // Reaction query types (fusion, fission, twotwo)
+    if (query.queryType === 'fusion' || query.queryType === 'fission' || query.queryType === 'twotwo') {
+      if (query.element1List?.length) params.set('e1', query.element1List.join(','));
+      if (query.element2List?.length) params.set('e2', query.element2List.join(','));
+      if (query.outputElementList?.length) params.set('e', query.outputElementList.join(','));
+      if (query.filter.elements?.length) params.set('e', query.filter.elements.join(','));
+      if (query.filter.minMeV !== undefined) params.set('minMeV', String(query.filter.minMeV));
+      if (query.filter.maxMeV !== undefined) params.set('maxMeV', String(query.filter.maxMeV));
+
+      const routes = { fusion: '/fusion', fission: '/fission', twotwo: '/twotwo' } as const;
+      const search = params.toString();
+      navigate(`${routes[query.queryType]}${search ? `?${search}` : ''}`);
+      return;
+    }
+
+    // Element data links
+    if (query.queryType === 'element-data') {
+      if (query.elementZ !== undefined) params.set('Z', String(query.elementZ));
+      if (query.elementA !== undefined) params.set('A', String(query.elementA));
+      navigate(`/element-data?${params.toString()}`);
+      return;
+    }
+
+    // Cascades links
+    if (query.queryType === 'cascades') {
+      if (query.materialId) params.set('material', query.materialId);
+      navigate(`/cascades?${params.toString()}`);
+      return;
+    }
+
+    // Muller Resonance links
+    if (query.queryType === 'muller-resonance') {
+      if (query.mullerParams) {
+        for (const [key, val] of Object.entries(query.mullerParams)) {
+          params.set(key, val);
+        }
+      }
+      navigate(`/muller-resonance?${params.toString()}`);
+      return;
+    }
   };
 
   return (
@@ -74,7 +105,7 @@ export default function Help() {
                   {query.name}
                 </h3>
                 <span className="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 shrink-0 ml-2">
-                  {query.queryType === 'twotwo' ? '2→2' : query.queryType}
+                  {{ fusion: 'fusion', fission: 'fission', twotwo: '2→2', 'element-data': 'element', cascades: 'cascade', 'muller-resonance': 'resonance' }[query.queryType]}
                 </span>
               </div>
               <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">


### PR DESCRIPTION
## Summary

Clean, no-conflicts version of #164 — Bryan's Help-examples diversification rebased directly onto `main` so it no longer inherits the failing stack (#164 → #163 → #162).

### What this adds
- Rebalance Help page examples from 4/3/3 (fusion/fission/twotwo only) to cover all 6 page types:
  - **Fusion** (2): H+Li classic, Ni+H Rossi/Parkhomov
  - **Fission** (2): Uranium, Palladium (Fleischmann-Pons)
  - **Two-to-Two** (2): H+B aneutronic, D+Ni
  - **Element Data** (2): U-238 decay chain, Fe-56 binding energy peak
  - **Muller Resonance** (1): Palladium NAE analysis with filter
  - **Cascades** (1): Parkhomov Ni-LiAlH4 preset
- Extend `ExampleQuery` type with `element-data`, `cascades`, `muller-resonance` query types
- Update `Help.tsx` routing to navigate to all page types with correct URL params
- Update badge labels for the new query types

### Why a new PR
#164 was based on `deep-link-cascades-muller` (#163), which is based on `refresh-landing-page-copy` (#162). #162's CI fails on the Nanosoft heading rename, so every PR in that stack fails CI by inheritance. Rebasing onto `main` detaches from the failing dependency chain — the commit applies cleanly with zero conflicts. The underlying commit is Bryan's f88e22f, unchanged.

### Relation to #166 (URL deep-linking)
The Cascades and Muller Resonance example cards navigate to URLs like `/cascades?material=parkhomov-2014` and `/muller-resonance?tab=nae&naeFilter=true`. Those params are only honored once **#166** lands (the clean version of Bryan's #163). Until then the navigation works but does not prefill the material/element — graceful degradation, no errors. Landing #166 first is the preferred order; if this merges first, the Help clicks still navigate correctly, they just don't set initial state.

### Test plan
- [x] `npm run build` passes
- [x] `vitest run src/data/exampleQueries.test.ts` — 9/9 pass
- [x] Cherry-pick onto `main` is clean (no conflicts)
- [ ] Playwright CI green on Chromium, Firefox, WebKit
- [ ] Click each of the 10 example cards — verify navigation to correct page
- [ ] After #166 merges: verify URL params prefill Cascades / Muller Resonance state

Closes #164 if merged.

Co-authored-by: Bryan White &lt;bryanchriswhite@gmail.com&gt;

🤖 Generated with [Claude Code](https://claude.com/claude-code)
