### PR TITLE
Diversify Help page examples across all page types

### DIFF
--- a/e2e/tests/help-page.spec.ts
+++ b/e2e/tests/help-page.spec.ts
@@ -19,7 +19,7 @@ test.describe('Help Page', () => {
 
   test('should display example query cards with names and descriptions', async ({ page }) => {
     await expect(page.getByText('Hydrogen-Lithium Fusion')).toBeVisible();
-    await expect(page.getByText('Deuterium-Deuterium Fusion')).toBeVisible();
+    await expect(page.getByText('Nickel-Hydrogen Fusion')).toBeVisible();
     await expect(page.getByText('Uranium Fission Pathways')).toBeVisible();
   });
 

--- a/src/data/exampleQueries.test.ts
+++ b/src/data/exampleQueries.test.ts
@@ -10,7 +10,7 @@ describe('exampleQueries', () => {
     EXAMPLE_QUERIES.forEach(query => {
       expect(query.name).toBeTruthy();
       expect(query.description).toBeTruthy();
-      expect(['fusion', 'fission', 'twotwo']).toContain(query.queryType);
+      expect(['fusion', 'fission', 'twotwo', 'element-data', 'cascades', 'muller-resonance']).toContain(query.queryType);
       expect(query.filter).toBeDefined();
     });
   });
@@ -30,16 +30,35 @@ describe('exampleQueries', () => {
     expect(twotwo.length).toBeGreaterThan(0);
   });
 
+  it('includes element-data examples', () => {
+    const elementData = EXAMPLE_QUERIES.filter(q => q.queryType === 'element-data');
+    expect(elementData.length).toBeGreaterThan(0);
+    elementData.forEach(q => {
+      expect(q.elementZ).toBeDefined();
+    });
+  });
+
+  it('includes cascades example', () => {
+    const cascades = EXAMPLE_QUERIES.filter(q => q.queryType === 'cascades');
+    expect(cascades.length).toBeGreaterThan(0);
+    cascades.forEach(q => {
+      expect(q.materialId).toBeTruthy();
+    });
+  });
+
+  it('includes muller-resonance example', () => {
+    const muller = EXAMPLE_QUERIES.filter(q => q.queryType === 'muller-resonance');
+    expect(muller.length).toBeGreaterThan(0);
+    muller.forEach(q => {
+      expect(q.mullerParams).toBeDefined();
+    });
+  });
+
   it('includes H-Li fusion example', () => {
     const hli = EXAMPLE_QUERIES.find(q =>
       q.element1List?.includes('H') && q.element2List?.includes('Li')
     );
     expect(hli).toBeDefined();
     expect(hli!.queryType).toBe('fusion');
-  });
-
-  it('includes high-energy fusion example', () => {
-    const highE = EXAMPLE_QUERIES.find(q => q.filter.minMeV && q.filter.minMeV >= 10);
-    expect(highE).toBeDefined();
   });
 });

--- a/src/data/exampleQueries.ts
+++ b/src/data/exampleQueries.ts
@@ -3,29 +3,28 @@ import { QueryFilter } from '../types';
 export interface ExampleQuery {
   name: string;
   description: string;
-  queryType: 'fusion' | 'fission' | 'twotwo';
+  queryType: 'fusion' | 'fission' | 'twotwo' | 'element-data' | 'cascades' | 'muller-resonance';
   filter: QueryFilter;
   element1List?: string[];
   element2List?: string[];
   outputElementList?: string[];
+  /** For element-data links: Z and optional A */
+  elementZ?: number;
+  elementA?: number;
+  /** For cascades links: material preset ID or fuel list */
+  materialId?: string;
+  /** For muller-resonance links: URL params */
+  mullerParams?: Record<string, string>;
 }
 
 export const EXAMPLE_QUERIES: ExampleQuery[] = [
-  // Fusion examples
+  // Fusion examples (2)
   {
     name: 'Hydrogen-Lithium Fusion',
     description: 'Classic LENR reaction pathway. H + Li fusion produces beryllium and helium isotopes with significant energy release.',
     queryType: 'fusion',
     element1List: ['H'],
     element2List: ['Li'],
-    filter: {},
-  },
-  {
-    name: 'Deuterium-Deuterium Fusion',
-    description: 'D + D reactions are central to fusion research. Produces He-3 or tritium depending on the pathway.',
-    queryType: 'fusion',
-    element1List: ['D'],
-    element2List: ['D'],
     filter: {},
   },
   {
@@ -36,25 +35,13 @@ export const EXAMPLE_QUERIES: ExampleQuery[] = [
     element2List: ['Ni'],
     filter: {},
   },
-  {
-    name: 'High-Energy Fusion (>10 MeV)',
-    description: 'Find fusion reactions releasing more than 10 MeV of energy. Shows the most energetic transmutation pathways.',
-    queryType: 'fusion',
-    filter: { minMeV: 10 },
-  },
 
-  // Fission examples
+  // Fission examples (2)
   {
     name: 'Uranium Fission Pathways',
     description: 'All fission pathways from uranium isotopes. Shows the diverse product spectrum of uranium splitting.',
     queryType: 'fission',
     filter: { elements: ['U'] },
-  },
-  {
-    name: 'Iron Fission',
-    description: 'Exothermic fission pathways from iron isotopes. Iron-56 has near-peak binding energy per nucleon, so fewer exothermic fission pathways exist compared to heavier elements.',
-    queryType: 'fission',
-    filter: { elements: ['Fe'] },
   },
   {
     name: 'Palladium Fission',
@@ -63,15 +50,7 @@ export const EXAMPLE_QUERIES: ExampleQuery[] = [
     filter: { elements: ['Pd'] },
   },
 
-  // Two-to-Two examples
-  {
-    name: 'Deuterium-Nickel Reactions',
-    description: 'D + Ni two-to-two reactions. The default query showing deuterium-based transmutations with nickel, lithium, aluminum, boron, and nitrogen.',
-    queryType: 'twotwo',
-    element1List: ['D'],
-    element2List: ['Ni', 'Li', 'Al', 'B', 'N'],
-    filter: {},
-  },
+  // Two-to-Two examples (2)
   {
     name: 'Proton-Boron Reactions',
     description: 'H + B-11 produces three alpha particles in the aneutronic fusion reaction (p + B-11 → 3α), considered ideal for clean energy.',
@@ -81,11 +60,47 @@ export const EXAMPLE_QUERIES: ExampleQuery[] = [
     filter: {},
   },
   {
-    name: 'Lithium-Lithium Reactions',
-    description: 'Li + Li two-to-two reactions. Lithium is a key element in LENR research due to its low atomic number and high reactivity.',
+    name: 'Deuterium-Nickel Reactions',
+    description: 'D + Ni two-to-two reactions showing deuterium-based transmutations with nickel, lithium, aluminum, boron, and nitrogen.',
     queryType: 'twotwo',
-    element1List: ['Li'],
-    element2List: ['Li'],
+    element1List: ['D'],
+    element2List: ['Ni', 'Li', 'Al', 'B', 'N'],
+    filter: {},
+  },
+
+  // Element Data examples (2)
+  {
+    name: 'Uranium-238 Decay Chain',
+    description: 'The most famous natural decay series (4n+2). Trace 14 steps from U-238 through radium and radon down to stable Pb-206.',
+    queryType: 'element-data',
+    elementZ: 92,
+    elementA: 238,
+    filter: {},
+  },
+  {
+    name: 'Iron-56 — Peak Binding Energy',
+    description: 'Fe-56 has the highest binding energy per nucleon of any nuclide, making it the endpoint of stellar nucleosynthesis.',
+    queryType: 'element-data',
+    elementZ: 26,
+    elementA: 56,
+    filter: {},
+  },
+
+  // Muller Resonance example (1)
+  {
+    name: 'Palladium NAE Analysis',
+    description: 'Explore palladium\'s nuclear active environment predictions — central to Fleischmann-Pons deuterium loading experiments.',
+    queryType: 'muller-resonance',
+    mullerParams: { tab: 'nae', element: 'Pd', naeFilter: 'true' },
+    filter: {},
+  },
+
+  // Cascades example (1)
+  {
+    name: 'Parkhomov Ni-LiAlH₄ Cascade',
+    description: 'Simulate the 2014 Parkhomov replication of the Rossi reactor using natural nickel with lithium aluminum hydride fuel.',
+    queryType: 'cascades',
+    materialId: 'parkhomov-2014',
     filter: {},
   },
 ];

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1057,6 +1057,7 @@
       "knownLENR": "Bekannte LENR",
       "parkhomovReactions": "Parkhomov-Rxn.",
       "showNAEOnly": "Nur Elemente mit Resonanz im NAE-Bereich anzeigen",
+      "searchPlaceholder": "Nach Element filtern (kommagetrennt)...",
       "elementsInRange": "Elemente im NAE-Bereich (0,5–2,0 nm)",
       "withDOverlap": "Mit D-Überlappung (<30%)",
       "confirmedLENR": "Bekannte LENR-aktive",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1057,6 +1057,7 @@
       "knownLENR": "Known LENR",
       "parkhomovReactions": "Parkhomov Rxns",
       "showNAEOnly": "Show only elements with resonance in NAE range",
+      "searchPlaceholder": "Filter by element (comma delimited)...",
       "elementsInRange": "Elements in NAE range (0.5–2.0 nm)",
       "withDOverlap": "With D overlap (<30%)",
       "confirmedLENR": "Known LENR-active",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1057,6 +1057,7 @@
       "knownLENR": "LENR conocida",
       "parkhomovReactions": "Rxns Parkhomov",
       "showNAEOnly": "Mostrar solo elementos con resonancia en rango NAE",
+      "searchPlaceholder": "Filtrar por elemento (separado por comas)...",
       "elementsInRange": "Elementos en rango NAE (0,5–2,0 nm)",
       "withDOverlap": "Con superposición D (<30%)",
       "confirmedLENR": "LENR activa conocida",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1057,6 +1057,7 @@
       "knownLENR": "LENR connue",
       "parkhomovReactions": "Rxns Parkhomov",
       "showNAEOnly": "Afficher uniquement les éléments avec résonance dans la plage NAE",
+      "searchPlaceholder": "Filtrer par élément (séparé par virgules)...",
       "elementsInRange": "Éléments dans la plage NAE (0,5–2,0 nm)",
       "withDOverlap": "Avec chevauchement D (<30%)",
       "confirmedLENR": "LENR active connue",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1057,6 +1057,7 @@
       "knownLENR": "既知のLENR",
       "parkhomovReactions": "パルホモフ反応",
       "showNAEOnly": "NAE範囲に共鳴を持つ元素のみ表示",
+      "searchPlaceholder": "元素で絞り込み（カンマ区切り）...",
       "elementsInRange": "NAE範囲内の元素 (0.5–2.0 nm)",
       "withDOverlap": "D重複あり (<30%)",
       "confirmedLENR": "既知のLENR活性",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1057,6 +1057,7 @@
       "knownLENR": "Известный LENR",
       "parkhomovReactions": "Реакции Пархомова",
       "showNAEOnly": "Показать только элементы с резонансом в диапазоне NAE",
+      "searchPlaceholder": "Фильтр по элементу (через запятую)...",
       "elementsInRange": "Элементы в диапазоне NAE (0,5–2,0 нм)",
       "withDOverlap": "С перекрытием D (<30%)",
       "confirmedLENR": "Известные LENR-активные",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1057,6 +1057,7 @@
       "knownLENR": "已知LENR",
       "parkhomovReactions": "帕尔霍莫夫反应",
       "showNAEOnly": "仅显示NAE范围内有共振的元素",
+      "searchPlaceholder": "按元素筛选（逗号分隔）...",
       "elementsInRange": "NAE范围内元素（0.5–2.0 nm）",
       "withDOverlap": "有D重叠（<30%）",
       "confirmedLENR": "已知LENR活性",

--- a/src/pages/CascadesAll.tsx
+++ b/src/pages/CascadesAll.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
 import { Play, Settings, AlertCircle, CheckCircle, XCircle, Loader2, Download, Scale, BookOpen } from 'lucide-react'
 import { useDatabase } from '../contexts/DatabaseContext'
 import { useQueryState } from '../contexts/QueryStateContext'
@@ -12,42 +13,132 @@ import MaterialsCatalog from '../components/MaterialsCatalog'
 import DatabaseLoadingCard from '../components/DatabaseLoadingCard'
 import { getAllElements } from '../services/queryService'
 import { createEqualProportions } from '../services/proportionService'
+import { getMaterialById } from '../constants/materials'
 import type { CascadeResults, Element, WeightedNuclide, ProportionFormat } from '../types'
+
+// Parse URL search params into cascade state (returns null fields when param is absent)
+function parseUrlParams(searchParams: URLSearchParams) {
+  const has = searchParams.toString().length > 0
+  if (!has) return null
+
+  const str = (key: string) => searchParams.get(key)
+  const num = (key: string) => { const v = searchParams.get(key); return v !== null ? parseFloat(v) : undefined }
+  const bool = (key: string) => { const v = searchParams.get(key); return v !== null ? v === 'true' : undefined }
+  const list = (key: string) => { const v = searchParams.get(key); return v ? v.split(',') : undefined }
+
+  // Resolve ?material= to fuel nuclides + weighted mode
+  const materialId = str('material')
+  let materialFuel: WeightedNuclide[] | undefined
+  let materialNuclides: string[] | undefined
+  if (materialId) {
+    const mat = getMaterialById(materialId)
+    if (mat) {
+      materialFuel = mat.composition.map(c => ({
+        nuclideId: c.nuclideId,
+        proportion: c.proportion,
+        sourceType: 'material' as const,
+      }))
+      materialNuclides = mat.composition.map(c => c.nuclideId)
+    }
+  }
+
+  return {
+    fuel: list('fuel') ?? materialNuclides,
+    temperature: num('temp'),
+    minFusionMeV: num('minFusionMeV'),
+    minTwoToTwoMeV: num('minTwoToTwoMeV'),
+    maxLoops: num('maxLoops'),
+    maxNuclides: num('maxNuclides'),
+    feedbackBosons: bool('feedbackBosons'),
+    feedbackFermions: bool('feedbackFermions'),
+    allowDimers: bool('allowDimers'),
+    excludeMelted: bool('excludeMelted'),
+    excludeBoiledOff: bool('excludeBoiledOff'),
+    materialFuel,
+    useWeightedMode: materialFuel ? true : undefined,
+  }
+}
+
+const DEFAULT_PARAMS = {
+  temperature: 2400,
+  minFusionMeV: 1.0,
+  minTwoToTwoMeV: 1.0,
+  maxNuclides: 5000,
+  maxLoops: 25,
+  feedbackBosons: true,
+  feedbackFermions: true,
+  allowDimers: true,
+  excludeMelted: false,
+  excludeBoiledOff: true,
+}
+
+const DEFAULT_FUEL = ['H-1', 'Li-7', 'Al-27', 'N-14', 'Ni-58', 'Ni-60', 'Ni-62', 'B-10', 'B-11']
 
 export default function CascadesAll() {
   const { t } = useTranslation()
   const { db, isLoading: dbLoading, error: dbError, downloadProgress } = useDatabase()
   const { getCascadeState, updateCascadeState } = useQueryState()
   const { runCascade, cancelCascade, progress, isRunning, error: workerError } = useCascadeWorker()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const hasUrlParams = useRef(searchParams.toString().length > 0)
+  const isInitialMount = useRef(true)
   const [hasRestoredFromContext, setHasRestoredFromContext] = useState(false)
 
-  const [params, setParams] = useState({
-    temperature: 2400,
-    minFusionMeV: 1.0,
-    minTwoToTwoMeV: 1.0,
-    maxNuclides: 5000,
-    maxLoops: 25,
-    feedbackBosons: true,
-    feedbackFermions: true,
-    allowDimers: true,
-    excludeMelted: false,
-    excludeBoiledOff: true,
+  // Parse URL params once on mount
+  const urlState = useRef(parseUrlParams(searchParams))
+
+  const [params, setParams] = useState(() => {
+    const u = urlState.current
+    if (!u) return { ...DEFAULT_PARAMS }
+    return {
+      temperature: u.temperature ?? DEFAULT_PARAMS.temperature,
+      minFusionMeV: u.minFusionMeV ?? DEFAULT_PARAMS.minFusionMeV,
+      minTwoToTwoMeV: u.minTwoToTwoMeV ?? DEFAULT_PARAMS.minTwoToTwoMeV,
+      maxNuclides: u.maxNuclides ?? DEFAULT_PARAMS.maxNuclides,
+      maxLoops: u.maxLoops ?? DEFAULT_PARAMS.maxLoops,
+      feedbackBosons: u.feedbackBosons ?? DEFAULT_PARAMS.feedbackBosons,
+      feedbackFermions: u.feedbackFermions ?? DEFAULT_PARAMS.feedbackFermions,
+      allowDimers: u.allowDimers ?? DEFAULT_PARAMS.allowDimers,
+      excludeMelted: u.excludeMelted ?? DEFAULT_PARAMS.excludeMelted,
+      excludeBoiledOff: u.excludeBoiledOff ?? DEFAULT_PARAMS.excludeBoiledOff,
+    }
   })
 
   // Local state for sliders during dragging (prevents performance issues)
-  const [sliderMaxNuclides, setSliderMaxNuclides] = useState(5000)
-  const [sliderMaxLoops, setSliderMaxLoops] = useState(25)
+  const [sliderMaxNuclides, setSliderMaxNuclides] = useState(() => urlState.current?.maxNuclides ?? DEFAULT_PARAMS.maxNuclides)
+  const [sliderMaxLoops, setSliderMaxLoops] = useState(() => urlState.current?.maxLoops ?? DEFAULT_PARAMS.maxLoops)
 
   const [availableElements, setAvailableElements] = useState<Element[]>([])
-  const [fuelNuclides, setFuelNuclides] = useState<string[]>(['H-1', 'Li-7', 'Al-27', 'N-14', 'Ni-58', 'Ni-60', 'Ni-62', 'B-10', 'B-11'])
+  const [fuelNuclides, setFuelNuclides] = useState<string[]>(() => urlState.current?.fuel ?? DEFAULT_FUEL)
   const [results, setResults] = useState<CascadeResults | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   // Weighted mode state (Issue #96)
-  const [useWeightedMode, setUseWeightedMode] = useState(false)
-  const [weightedFuel, setWeightedFuel] = useState<WeightedNuclide[]>([])
+  const [useWeightedMode, setUseWeightedMode] = useState(() => urlState.current?.useWeightedMode ?? false)
+  const [weightedFuel, setWeightedFuel] = useState<WeightedNuclide[]>(() => urlState.current?.materialFuel ?? [])
   const [proportionFormat, setProportionFormat] = useState<ProportionFormat>('percentage')
   const [showMaterialsCatalog, setShowMaterialsCatalog] = useState(false)
+
+  // Sync state → URL params (skip initial mount)
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+      return
+    }
+    const p = new URLSearchParams()
+    if (fuelNuclides.join(',') !== DEFAULT_FUEL.join(',')) p.set('fuel', fuelNuclides.join(','))
+    if (params.temperature !== DEFAULT_PARAMS.temperature) p.set('temp', String(params.temperature))
+    if (params.minFusionMeV !== DEFAULT_PARAMS.minFusionMeV) p.set('minFusionMeV', String(params.minFusionMeV))
+    if (params.minTwoToTwoMeV !== DEFAULT_PARAMS.minTwoToTwoMeV) p.set('minTwoToTwoMeV', String(params.minTwoToTwoMeV))
+    if (params.maxLoops !== DEFAULT_PARAMS.maxLoops) p.set('maxLoops', String(params.maxLoops))
+    if (params.maxNuclides !== DEFAULT_PARAMS.maxNuclides) p.set('maxNuclides', String(params.maxNuclides))
+    if (params.feedbackBosons !== DEFAULT_PARAMS.feedbackBosons) p.set('feedbackBosons', String(params.feedbackBosons))
+    if (params.feedbackFermions !== DEFAULT_PARAMS.feedbackFermions) p.set('feedbackFermions', String(params.feedbackFermions))
+    if (params.allowDimers !== DEFAULT_PARAMS.allowDimers) p.set('allowDimers', String(params.allowDimers))
+    if (params.excludeMelted !== DEFAULT_PARAMS.excludeMelted) p.set('excludeMelted', String(params.excludeMelted))
+    if (params.excludeBoiledOff !== DEFAULT_PARAMS.excludeBoiledOff) p.set('excludeBoiledOff', String(params.excludeBoiledOff))
+    setSearchParams(p, { replace: true })
+  }, [fuelNuclides, params, setSearchParams])
 
   // Load available elements and restore state when database is ready
   useEffect(() => {
@@ -55,10 +146,10 @@ export default function CascadesAll() {
       const elements = getAllElements(db)
       setAvailableElements(elements)
 
-      // Restore state from context if not already done
+      // Restore state from context if not already done (skip if URL params provided)
       if (!hasRestoredFromContext) {
         const savedState = getCascadeState()
-        if (savedState) {
+        if (savedState && !hasUrlParams.current) {
           setParams({
             temperature: savedState.temperature,
             minFusionMeV: savedState.minFusionMeV,
@@ -216,21 +307,10 @@ export default function CascadesAll() {
   }
 
   const handleReset = () => {
-    setParams({
-      temperature: 2400,
-      minFusionMeV: 1.0,
-      minTwoToTwoMeV: 1.0,
-      maxNuclides: 5000,
-      maxLoops: 25,
-      feedbackBosons: true,
-      feedbackFermions: true,
-      allowDimers: true,
-      excludeMelted: false,
-      excludeBoiledOff: true,
-    })
-    setSliderMaxNuclides(5000)
-    setSliderMaxLoops(25)
-    setFuelNuclides(['H-1', 'Li-7', 'Al-27', 'N-14', 'Ni-58', 'Ni-60', 'Ni-62', 'B-10', 'B-11'])
+    setParams({ ...DEFAULT_PARAMS })
+    setSliderMaxNuclides(DEFAULT_PARAMS.maxNuclides)
+    setSliderMaxLoops(DEFAULT_PARAMS.maxLoops)
+    setFuelNuclides([...DEFAULT_FUEL])
     setResults(null)
     setError(null)
     // Reset weighted mode state

--- a/src/pages/CascadesAll.tsx
+++ b/src/pages/CascadesAll.tsx
@@ -22,7 +22,7 @@ function parseUrlParams(searchParams: URLSearchParams) {
   if (!has) return null
 
   const str = (key: string) => searchParams.get(key)
-  const num = (key: string) => { const v = searchParams.get(key); return v !== null ? parseFloat(v) : undefined }
+  const num = (key: string) => { const v = searchParams.get(key); if (v === null) return undefined; const n = parseFloat(v); return isNaN(n) ? undefined : n }
   const bool = (key: string) => { const v = searchParams.get(key); return v !== null ? v === 'true' : undefined }
   const list = (key: string) => { const v = searchParams.get(key); return v ? v.split(',') : undefined }
 

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -27,16 +27,51 @@ export default function Help() {
 
   const handleTryQuery = (query: ExampleQuery) => {
     const params = new URLSearchParams();
-    if (query.element1List?.length) params.set('e1', query.element1List.join(','));
-    if (query.element2List?.length) params.set('e2', query.element2List.join(','));
-    if (query.outputElementList?.length) params.set('e', query.outputElementList.join(','));
-    if (query.filter.elements?.length) params.set('e', query.filter.elements.join(','));
-    if (query.filter.minMeV !== undefined) params.set('minMeV', String(query.filter.minMeV));
-    if (query.filter.maxMeV !== undefined) params.set('maxMeV', String(query.filter.maxMeV));
 
-    const routes = { fusion: '/fusion', fission: '/fission', twotwo: '/twotwo' };
-    const search = params.toString();
-    navigate(`${routes[query.queryType]}${search ? `?${search}` : ''}`);
+    // Reaction query types (fusion, fission, twotwo)
+    if (query.queryType === 'fusion' || query.queryType === 'fission' || query.queryType === 'twotwo') {
+      if (query.element1List?.length) params.set('e1', query.element1List.join(','));
+      if (query.element2List?.length) params.set('e2', query.element2List.join(','));
+      if (query.outputElementList?.length) params.set('e', query.outputElementList.join(','));
+      if (query.filter.elements?.length) params.set('e', query.filter.elements.join(','));
+      if (query.filter.minMeV !== undefined) params.set('minMeV', String(query.filter.minMeV));
+      if (query.filter.maxMeV !== undefined) params.set('maxMeV', String(query.filter.maxMeV));
+
+      const routes = { fusion: '/fusion', fission: '/fission', twotwo: '/twotwo' } as const;
+      const search = params.toString();
+      navigate(`${routes[query.queryType]}${search ? `?${search}` : ''}`);
+      return;
+    }
+
+    // Element data links
+    if (query.queryType === 'element-data') {
+      if (query.elementZ !== undefined) params.set('Z', String(query.elementZ));
+      if (query.elementA !== undefined) params.set('A', String(query.elementA));
+      navigate(`/element-data?${params.toString()}`);
+      return;
+    }
+
+    // Cascades links
+    if (query.queryType === 'cascades') {
+      if (query.materialId) params.set('material', query.materialId);
+      navigate(`/cascades?${params.toString()}`);
+      return;
+    }
+
+    // Muller Resonance links
+    if (query.queryType === 'muller-resonance') {
+      if (query.mullerParams) {
+        for (const [key, val] of Object.entries(query.mullerParams)) {
+          params.set(key, val);
+        }
+      }
+      navigate(`/muller-resonance?${params.toString()}`);
+      return;
+    }
+
+    // Exhaustiveness check — ensures all queryType values are handled
+    const _exhaustive: never = query.queryType;
+    console.warn(`Unhandled query type: ${_exhaustive}`);
   };
 
   return (
@@ -74,7 +109,7 @@ export default function Help() {
                   {query.name}
                 </h3>
                 <span className="text-xs px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 shrink-0 ml-2">
-                  {query.queryType === 'twotwo' ? '2→2' : query.queryType}
+                  {{ fusion: 'fusion', fission: 'fission', twotwo: '2→2', 'element-data': 'element', cascades: 'cascade', 'muller-resonance': 'resonance' }[query.queryType]}
                 </span>
               </div>
               <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">

--- a/src/pages/MullerResonance.tsx
+++ b/src/pages/MullerResonance.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
 import { useDatabase } from '../contexts/DatabaseContext'
@@ -27,18 +27,32 @@ type SortDirection = 'asc' | 'desc'
 export default function MullerResonance() {
   const { t } = useTranslation()
   const { db, isLoading: dbLoading, downloadProgress } = useDatabase()
-  const [searchParams] = useSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const isInitialMount = useRef(true)
   const [elements, setElements] = useState<Element[]>([])
-  const [selectedElement, setSelectedElement] = useState<string | null>(null)
-  const [threshold, setThreshold] = useState(5.0)
+
+  // Initialize state from URL params (read once on mount)
+  const [selectedElement, setSelectedElement] = useState<string | null>(
+    searchParams.get('element') || null
+  )
+  const [threshold, setThreshold] = useState(() => {
+    const p = searchParams.get('threshold')
+    return p ? parseFloat(p) : 5.0
+  })
 
   // Tab state
   const [activeTab, setActiveTab] = useState(searchParams.get('tab') || 'resonance')
 
   // NAE UI state
-  const [naeFilter, setNaeFilter] = useState(false)
-  const [naeSortColumn, setNaeSortColumn] = useState<SortColumn>('naeScore')
-  const [naeSortDirection, setNaeSortDirection] = useState<SortDirection>('asc')
+  const [naeFilter, setNaeFilter] = useState(searchParams.get('naeFilter') === 'true')
+  const [naeSortColumn, setNaeSortColumn] = useState<SortColumn>(() => {
+    const p = searchParams.get('sort') as SortColumn | null
+    return p && ['element', 'naeScore', 'wavelength', 'deuterium', 'phonon', 'reactions', 'lenr'].includes(p) ? p : 'naeScore'
+  })
+  const [naeSortDirection, setNaeSortDirection] = useState<SortDirection>(() => {
+    const p = searchParams.get('dir') as SortDirection | null
+    return p === 'desc' ? 'desc' : 'asc'
+  })
   const [expandedRow, setExpandedRow] = useState<number | null>(null)
 
   // Worker handles all heavy computation off the main thread
@@ -59,6 +73,22 @@ export default function MullerResonance() {
     { id: 'resonance', label: t('mullerResonance.tabs.resonancePairs') },
     { id: 'nae', label: t('mullerResonance.tabs.naePredictions') },
   ], [t])
+
+  // Sync state → URL params (skip initial mount to avoid replacing URL on load)
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+      return
+    }
+    const params = new URLSearchParams()
+    if (activeTab !== 'resonance') params.set('tab', activeTab)
+    if (selectedElement) params.set('element', selectedElement)
+    if (threshold !== 5.0) params.set('threshold', String(threshold))
+    if (naeFilter) params.set('naeFilter', 'true')
+    if (activeTab === 'nae' && naeSortColumn !== 'naeScore') params.set('sort', naeSortColumn)
+    if (activeTab === 'nae' && naeSortDirection !== 'asc') params.set('dir', naeSortDirection)
+    setSearchParams(params, { replace: true })
+  }, [activeTab, selectedElement, threshold, naeFilter, naeSortColumn, naeSortDirection, setSearchParams])
 
   // Load elements and initialize worker
   useEffect(() => {

--- a/src/pages/MullerResonance.tsx
+++ b/src/pages/MullerResonance.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
+import { Search } from 'lucide-react'
 import { useDatabase } from '../contexts/DatabaseContext'
 import { getAllElements } from '../services/queryService'
 import { useMullerWorker } from '../hooks/useMullerWorker'
@@ -56,6 +57,8 @@ export default function MullerResonance() {
     return p === 'desc' ? 'desc' : 'asc'
   })
   const [expandedRow, setExpandedRow] = useState<number | null>(null)
+  const [naeSearch, setNaeSearch] = useState(searchParams.get('search') || '')
+  const expandedRowRef = useRef<HTMLDivElement>(null)
 
   // Worker handles all heavy computation off the main thread
   const {
@@ -89,8 +92,9 @@ export default function MullerResonance() {
     if (naeFilter) params.set('naeFilter', 'true')
     if (activeTab === 'nae' && naeSortColumn !== 'naeScore') params.set('sort', naeSortColumn)
     if (activeTab === 'nae' && naeSortDirection !== 'asc') params.set('dir', naeSortDirection)
+    if (activeTab === 'nae' && naeSearch) params.set('search', naeSearch)
     setSearchParams(params, { replace: true })
-  }, [activeTab, selectedElement, threshold, naeFilter, naeSortColumn, naeSortDirection, setSearchParams])
+  }, [activeTab, selectedElement, threshold, naeFilter, naeSortColumn, naeSortDirection, naeSearch, setSearchParams])
 
   // Load elements and initialize worker
   useEffect(() => {
@@ -106,6 +110,22 @@ export default function MullerResonance() {
   const handleElementClick = useCallback((symbol: string) => {
     setSelectedElement(prev => prev === symbol ? null : symbol)
   }, [])
+
+  // On NAE tab: auto-expand the selected element's detail row and scroll to it
+  useEffect(() => {
+    if (activeTab !== 'nae') return
+    if (!selectedElement) {
+      setExpandedRow(null)
+      return
+    }
+    const pred = naePredictions.find(p => p.E === selectedElement)
+    if (pred) {
+      setExpandedRow(pred.Z)
+      requestAnimationFrame(() => {
+        expandedRowRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      })
+    }
+  }, [activeTab, selectedElement, naePredictions])
 
   // Delegate element selection/clearing to worker
   useEffect(() => {
@@ -304,11 +324,19 @@ export default function MullerResonance() {
   const sortedNAEPredictions = useMemo(() => {
     let filtered = naePredictions
     if (naeFilter) {
-      filtered = naePredictions.filter(p =>
+      filtered = filtered.filter(p =>
         p.naeWavelength !== null &&
         p.naeWavelength >= NAE_GAP_MIN &&
         p.naeWavelength <= NAE_GAP_MAX
       )
+    }
+    if (naeSearch) {
+      const terms = naeSearch.split(',').map(s => s.trim().toLowerCase()).filter(Boolean)
+      if (terms.length > 0) {
+        filtered = filtered.filter(p =>
+          terms.some(term => p.E.toLowerCase().includes(term))
+        )
+      }
     }
 
     return [...filtered].sort((a, b) => {
@@ -332,7 +360,7 @@ export default function MullerResonance() {
         default: return 0
       }
     })
-  }, [naePredictions, naeFilter, naeSortColumn, naeSortDirection, reactionCounts])
+  }, [naePredictions, naeFilter, naeSearch, naeSortColumn, naeSortDirection, reactionCounts])
 
   const handleNAESort = useCallback((col: SortColumn) => {
     setNaeSortColumn(prev => {
@@ -593,7 +621,7 @@ export default function MullerResonance() {
             </p>
             <PeriodicTable
               availableElements={elements}
-              selectedElement={null}
+              selectedElement={selectedElement}
               onElementClick={handleElementClick}
               heatmapData={naeHeatmapData}
               heatmapMetrics={naeHeatmapMetrics}
@@ -614,22 +642,125 @@ export default function MullerResonance() {
             </div>
           </div>
 
-          {/* Filter toggle */}
+          {/* Expanded Row Detail — shown between periodic table and filters */}
+          {expandedRow !== null && (() => {
+            const pred = naePredictions.find(p => p.Z === expandedRow)
+            if (!pred) return null
+
+            return (
+              <div ref={expandedRowRef} className="card p-4 mb-6">
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
+                  {pred.E} (Z={pred.Z}) — {t('mullerResonance.nae.octaveDetail')}
+                </h3>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {/* Electron resonance octaves */}
+                  <div>
+                    <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      {t('mullerResonance.nae.electronOctaves')}
+                    </h4>
+                    <table className="w-full text-xs">
+                      <thead>
+                        <tr className="border-b border-gray-200 dark:border-gray-700">
+                          <th className="text-center py-1 px-2 text-gray-500 dark:text-gray-400">N</th>
+                          <th className="text-right py-1 px-2 text-gray-500 dark:text-gray-400">{t('mullerResonance.wavelength')}</th>
+                          <th className="text-center py-1 px-2 text-gray-500 dark:text-gray-400">{t('mullerResonance.nae.inNAERange')}</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {pred.electronResonances.map(res => {
+                          const inNAE = res.L >= NAE_GAP_MIN && res.L <= NAE_GAP_MAX
+                          return (
+                            <tr
+                              key={res.N}
+                              className={`border-b border-gray-50 dark:border-gray-800/50 ${
+                                inNAE ? 'bg-emerald-50 dark:bg-emerald-900/20 font-medium' : ''
+                              }`}
+                            >
+                              <td className="py-1 px-2 text-center text-gray-600 dark:text-gray-400">{res.N}</td>
+                              <td className="py-1 px-2 text-right font-mono text-gray-700 dark:text-gray-300">
+                                {formatWavelength(res.L)}
+                              </td>
+                              <td className="py-1 px-2 text-center">
+                                {inNAE ? (
+                                  <span className="text-emerald-600 dark:text-emerald-400">NAE</span>
+                                ) : null}
+                              </td>
+                            </tr>
+                          )
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  {/* Deuterium proton overlap */}
+                  <div>
+                    <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                      {t('mullerResonance.nae.deuteriumProtonResonance')}
+                    </h4>
+                    {pred.naeWavelength !== null ? (
+                      <div className="space-y-2 text-xs text-gray-600 dark:text-gray-400">
+                        <p>
+                          {t('mullerResonance.nae.hostElectron')}: <strong className="text-gray-900 dark:text-white font-mono">{(pred.naeWavelength * 1e9).toFixed(2)} nm</strong> (N={pred.naeOctave})
+                        </p>
+                        {pred.deuteriumOverlapL !== null && (
+                          <>
+                            <p>
+                              {t('mullerResonance.nae.dProton')}: <strong className="text-gray-900 dark:text-white font-mono">{(pred.deuteriumOverlapL * 1e9).toFixed(2)} nm</strong> (N={pred.deuteriumOverlapN})
+                            </p>
+                            <p>
+                              {t('mullerResonance.nae.overlapMismatch')}: <strong className={`font-mono ${pred.deuteriumMismatch !== null && pred.deuteriumMismatch < 30 ? 'text-emerald-600 dark:text-emerald-400' : 'text-gray-900 dark:text-white'}`}>{pred.deuteriumMismatch?.toFixed(1)}%</strong>
+                            </p>
+                          </>
+                        )}
+                        {pred.phononFrequency !== null && pred.speedOfSound !== null && (
+                          <p>
+                            {t('mullerResonance.nae.phononCalc')}: {pred.speedOfSound.toLocaleString()} m/s / {(pred.naeWavelength * 1e9).toFixed(2)} nm = <strong className="text-gray-900 dark:text-white font-mono">{formatFrequency(pred.phononFrequency)}</strong>
+                          </p>
+                        )}
+                        {pred.lenrReference && (
+                          <p className="pt-1 border-t border-gray-200 dark:border-gray-700">
+                            {t('mullerResonance.nae.lenrRefs')}: <span className="text-gray-500 dark:text-gray-400">{pred.lenrReference}</span>
+                          </p>
+                        )}
+                      </div>
+                    ) : (
+                      <p className="text-xs text-gray-500 dark:text-gray-400">{t('mullerResonance.nae.noNAEResonance')}</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )
+          })()}
+
+          {/* Filters */}
           <div className="card p-4 mb-6">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={naeFilter}
-                onChange={(e) => setNaeFilter(e.target.checked)}
-                className="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
-              />
-              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                {t('mullerResonance.nae.showNAEOnly')}
-              </span>
-              <span className="text-xs text-gray-500 dark:text-gray-400">
-                (0.5–2.0 nm)
-              </span>
-            </label>
+            <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+              <div className="relative flex-1 max-w-xs">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                <input
+                  type="text"
+                  value={naeSearch}
+                  onChange={(e) => setNaeSearch(e.target.value)}
+                  placeholder={t('mullerResonance.nae.searchPlaceholder')}
+                  className="w-full pl-9 pr-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                />
+              </div>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={naeFilter}
+                  onChange={(e) => setNaeFilter(e.target.checked)}
+                  className="rounded border-gray-300 dark:border-gray-600 text-primary-600 focus:ring-primary-500"
+                />
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {t('mullerResonance.nae.showNAEOnly')}
+                </span>
+                <span className="text-xs text-gray-500 dark:text-gray-400">
+                  (0.5–2.0 nm)
+                </span>
+              </label>
+            </div>
           </div>
 
           {/* NAE Predictions Table */}
@@ -785,97 +916,6 @@ export default function MullerResonance() {
               </table>
             </div>
           </div>
-
-          {/* Expanded Row Detail */}
-          {expandedRow !== null && (() => {
-            const pred = naePredictions.find(p => p.Z === expandedRow)
-            if (!pred) return null
-
-            return (
-              <div className="card p-4 mb-6">
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
-                  {pred.E} (Z={pred.Z}) — {t('mullerResonance.nae.octaveDetail')}
-                </h3>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  {/* Electron resonance octaves */}
-                  <div>
-                    <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      {t('mullerResonance.nae.electronOctaves')}
-                    </h4>
-                    <table className="w-full text-xs">
-                      <thead>
-                        <tr className="border-b border-gray-200 dark:border-gray-700">
-                          <th className="text-center py-1 px-2 text-gray-500 dark:text-gray-400">N</th>
-                          <th className="text-right py-1 px-2 text-gray-500 dark:text-gray-400">{t('mullerResonance.wavelength')}</th>
-                          <th className="text-center py-1 px-2 text-gray-500 dark:text-gray-400">{t('mullerResonance.nae.inNAERange')}</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {pred.electronResonances.map(res => {
-                          const inNAE = res.L >= NAE_GAP_MIN && res.L <= NAE_GAP_MAX
-                          return (
-                            <tr
-                              key={res.N}
-                              className={`border-b border-gray-50 dark:border-gray-800/50 ${
-                                inNAE ? 'bg-emerald-50 dark:bg-emerald-900/20 font-medium' : ''
-                              }`}
-                            >
-                              <td className="py-1 px-2 text-center text-gray-600 dark:text-gray-400">{res.N}</td>
-                              <td className="py-1 px-2 text-right font-mono text-gray-700 dark:text-gray-300">
-                                {formatWavelength(res.L)}
-                              </td>
-                              <td className="py-1 px-2 text-center">
-                                {inNAE ? (
-                                  <span className="text-emerald-600 dark:text-emerald-400">NAE</span>
-                                ) : null}
-                              </td>
-                            </tr>
-                          )
-                        })}
-                      </tbody>
-                    </table>
-                  </div>
-
-                  {/* Deuterium proton overlap */}
-                  <div>
-                    <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      {t('mullerResonance.nae.deuteriumProtonResonance')}
-                    </h4>
-                    {pred.naeWavelength !== null ? (
-                      <div className="space-y-2 text-xs text-gray-600 dark:text-gray-400">
-                        <p>
-                          {t('mullerResonance.nae.hostElectron')}: <strong className="text-gray-900 dark:text-white font-mono">{(pred.naeWavelength * 1e9).toFixed(2)} nm</strong> (N={pred.naeOctave})
-                        </p>
-                        {pred.deuteriumOverlapL !== null && (
-                          <>
-                            <p>
-                              {t('mullerResonance.nae.dProton')}: <strong className="text-gray-900 dark:text-white font-mono">{(pred.deuteriumOverlapL * 1e9).toFixed(2)} nm</strong> (N={pred.deuteriumOverlapN})
-                            </p>
-                            <p>
-                              {t('mullerResonance.nae.overlapMismatch')}: <strong className={`font-mono ${pred.deuteriumMismatch !== null && pred.deuteriumMismatch < 30 ? 'text-emerald-600 dark:text-emerald-400' : 'text-gray-900 dark:text-white'}`}>{pred.deuteriumMismatch?.toFixed(1)}%</strong>
-                            </p>
-                          </>
-                        )}
-                        {pred.phononFrequency !== null && pred.speedOfSound !== null && (
-                          <p>
-                            {t('mullerResonance.nae.phononCalc')}: {pred.speedOfSound.toLocaleString()} m/s / {(pred.naeWavelength * 1e9).toFixed(2)} nm = <strong className="text-gray-900 dark:text-white font-mono">{formatFrequency(pred.phononFrequency)}</strong>
-                          </p>
-                        )}
-                        {pred.lenrReference && (
-                          <p className="pt-1 border-t border-gray-200 dark:border-gray-700">
-                            {t('mullerResonance.nae.lenrRefs')}: <span className="text-gray-500 dark:text-gray-400">{pred.lenrReference}</span>
-                          </p>
-                        )}
-                      </div>
-                    ) : (
-                      <p className="text-xs text-gray-500 dark:text-gray-400">{t('mullerResonance.nae.noNAEResonance')}</p>
-                    )}
-                  </div>
-                </div>
-              </div>
-            )
-          })()}
 
           {/* NAE Explanation Card */}
           <div className="card p-6 mb-6">

--- a/src/pages/MullerResonance.tsx
+++ b/src/pages/MullerResonance.tsx
@@ -37,7 +37,9 @@ export default function MullerResonance() {
   )
   const [threshold, setThreshold] = useState(() => {
     const p = searchParams.get('threshold')
-    return p ? parseFloat(p) : 5.0
+    if (!p) return 5.0
+    const n = parseFloat(p)
+    return isNaN(n) ? 5.0 : n
   })
 
   // Tab state


### PR DESCRIPTION
## Summary

Squash merge of #164 landed on `deep-link-cascades-muller` (its base branch) rather than main. This PR forwards that content to main.

Changes included:
- Rebalance Help page examples from fusion/fission/twotwo-only to cover all 6 page types
- Extend `ExampleQuery` type with `element-data`, `cascades`, `muller-resonance` query types
- Add exhaustiveness check to `handleTryQuery` switch
- Fix NAE tab element selection, auto-expand, search filter, and layout
- Update E2E and unit tests
- Add i18n translations for all new/modified UI across all 7 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)