### PR TITLE
fix(e2e): give transmutation pathway button a longer enable timeout

### DIFF
--- a/e2e/tests/transmutations.spec.ts
+++ b/e2e/tests/transmutations.spec.ts
@@ -30,11 +30,15 @@ test.describe('Transmutations Page', () => {
   });
 
   test('finds Parkhomov pathways for first card without errors', async ({ page }) => {
-    // Click the first "Find pathways" button (Iwamura Cs → Pr)
+    // Click the first "Find pathways" button (Iwamura Cs → Pr).
+    // The button is disabled until the React context's dbReady flag flips,
+    // which can lag behind the database-loading DOM marker waitForDatabaseReady
+    // checks for — especially on Firefox with a fresh (uncached) DB download.
+    // Use a generous timeout so the test doesn't flake on cold-cache CI runs.
     const firstButton = page
       .getByTestId(/find-pathways-/)
       .first();
-    await expect(firstButton).toBeEnabled();
+    await expect(firstButton).toBeEnabled({ timeout: 30000 });
     await firstButton.click();
 
     // Wait for either pathway results or "no pathways found" to appear.


### PR DESCRIPTION
## Summary
Firefox CI on `main` started failing the **'finds Parkhomov pathways for first card without errors'** test after PR #182 merged. The Find Parkhomov pathways button stays disabled past the default 5s assertion timeout.

## Root cause
The button binds to `dbReady = !!db && !dbLoading` from `useDatabase()`. The `waitForDatabaseReady` test helper waits for the `database-loading` DOM marker to disappear — but on Firefox with a fresh (uncached) DB download, the React context can lag the DOM marker by several seconds, long enough for the 5s `toBeEnabled()` assertion to fail.

The same test was flagged as flaky on Chromium during the preceding iteration session (passed on retry). This fix removes the flake on both browsers without changing app code.

## Fix
Bumped the `toBeEnabled` timeout from default 5s to 30s. Test-only one-liner.

## Test plan
- [x] Reproduces locally on Firefox (with fresh browser context simulating cold cache)
- [x] Passes on Chromium and Firefox after fix
- [x] No app code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)