### PR TITLE
fix: render DatabaseLoadingCard on Transmutations during DB load

### DIFF
--- a/e2e/tests/transmutations.spec.ts
+++ b/e2e/tests/transmutations.spec.ts
@@ -5,11 +5,6 @@ import {
 } from '../fixtures/test-helpers';
 
 test.describe('Transmutations Page', () => {
-  // The 60s global timeout is consumed by waitForDatabaseReady on cold-cache
-  // CI runs, leaving insufficient budget for the in-test toBeEnabled/toBeVisible
-  // waits. Override per-suite so the DB-load + pathway-search has 3 minutes.
-  test.describe.configure({ timeout: 180_000 });
-
   test.beforeEach(async ({ page }) => {
     await acceptPrivacyConsent(page);
     await page.goto('/transmutations');
@@ -35,24 +30,18 @@ test.describe('Transmutations Page', () => {
   });
 
   test('finds Parkhomov pathways for first card without errors', async ({ page }) => {
-    // Click the first "Find pathways" button (Iwamura Cs → Pr).
-    // The button is disabled until the React context's dbReady flag flips,
-    // which can lag behind the database-loading DOM marker waitForDatabaseReady
-    // checks for — especially on Firefox with a fresh (uncached) DB download.
-    // Use a generous timeout so the test doesn't flake on cold-cache CI runs.
     const firstButton = page
       .getByTestId(/find-pathways-/)
       .first();
-    await expect(firstButton).toBeEnabled({ timeout: 30000 });
+    await expect(firstButton).toBeEnabled();
     await firstButton.click();
 
-    // Wait for either pathway results or "no pathways found" to appear.
-    // We don't assert which — both are valid outcomes for the first cut.
+    // Either pathway results or "no pathways found" is a valid outcome.
     await expect(
       page
         .getByText(/Candidate pathways|No 1- or 2-step pathway found/i)
         .first()
-    ).toBeVisible({ timeout: 30000 });
+    ).toBeVisible();
   });
 
   test('category filter narrows the visible cards', async ({ page }) => {

--- a/src/pages/Transmutations.tsx
+++ b/src/pages/Transmutations.tsx
@@ -23,6 +23,7 @@ import {
 } from '../services/transmutationPathwayService'
 import TransmutationArrow from '../components/TransmutationArrow'
 import NuclideEquation from '../components/NuclideEquation'
+import DatabaseLoadingCard from '../components/DatabaseLoadingCard'
 
 const CATEGORY_KEYS: TransmutationCategory[] = [
   'solid-state',
@@ -48,7 +49,7 @@ interface PathwaySearchState {
 
 export default function Transmutations() {
   const { t } = useTranslation()
-  const { db, isLoading: dbLoading } = useDatabase()
+  const { db, isLoading: dbLoading, downloadProgress } = useDatabase()
   const [categoryFilter, setCategoryFilter] = useState<'all' | TransmutationCategory>('all')
   const [labFilter, setLabFilter] = useState<string>('all')
   const [searches, setSearches] = useState<Record<string, PathwaySearchState>>({})
@@ -176,6 +177,10 @@ export default function Transmutations() {
         },
       }))
     }
+  }
+
+  if (dbLoading || !db) {
+    return <DatabaseLoadingCard downloadProgress={downloadProgress} />
   }
 
   return (


### PR DESCRIPTION
## Summary
- Render `<DatabaseLoadingCard>` on `/transmutations` while the database is loading, matching `FusionQuery` and the other query pages
- Revert the 30s `toBeEnabled` timeout (and 180s per-suite timeout) from #183 — the root cause is now fixed

## Root cause
#183 bumped the `toBeEnabled` timeout from 5s → 30s to stop a flaky Firefox failure where the **Find Parkhomov pathways** button stayed disabled past the default assertion timeout. The PR notes attributed this to "React context lagging the DOM marker".

Looking at the page renders:
- `FusionQuery.tsx:622` returns `<DatabaseLoadingCard />` while `dbLoading`
- `Transmutations.tsx` rendered the full page immediately, button disabled via `!!db && !dbLoading`

`waitForDatabaseReady` waits for the `database-loading` DOM marker to disappear. Because that marker was never rendered on `/transmutations`, the helper returned **immediately**, and the test then polled `toBeEnabled()` against a button that was indefinitely disabled from its perspective. The 30s bump just gave the slow background load enough headroom to finish before the new ceiling.

## Fix
Render the loading card on `/transmutations` while `dbLoading || !db`. The DOM marker now accurately reflects React context state, the helper waits on a real signal, and the original 5s timeout is sufficient.

Users also get a visible download progress bar during the first cold-cache load instead of an inert page with a disabled button.

## Test plan
- [ ] CI green on Chromium and Firefox (WebKit may flake on unrelated specs)
- [ ] Manually verify the loading card shows on a cold cache, then disappears
- [ ] Manually verify pathway search still works once the DB is ready

Addresses follow-up to #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)