### PR TITLE
fix: validate TwoToTwoAll row schema in rowToReaction

### DIFF
--- a/src/services/transmutationPathwayService.ts
+++ b/src/services/transmutationPathwayService.ts
@@ -50,15 +50,45 @@ export interface FindPathwayOptions {
 const DEFAULT_MAX_RESULTS = 50;
 const DEFAULT_SEED_LIMIT = 200;
 
+/** Columns this service reads from a TwoToTwoAll row. */
+const REQUIRED_NUMBER_COLUMNS = [
+  'Z1', 'A1', 'Z2', 'A2', 'Z3', 'A3', 'Z4', 'A4', 'MeV',
+] as const;
+const REQUIRED_STRING_COLUMNS = ['E1', 'E2', 'E3', 'E4'] as const;
+
 /**
- * Convert a sql.js exec result row (array) into a TwoToTwoReaction-shaped object.
+ * Convert a sql.js exec result row (array) into a TwoToTwoReaction-shaped
+ * object. Validates that the columns this service actually reads (Z1..Z4,
+ * A1..A4, E1..E4, MeV) are present with the expected scalar type so that
+ * schema drift in TwoToTwoAll fails loudly instead of yielding undefined or
+ * NaN downstream.
  */
 function rowToReaction(columns: string[], row: unknown[]): TwoToTwoReaction {
   const obj: Record<string, unknown> = {};
   columns.forEach((col, idx) => {
     obj[col] = row[idx];
   });
-  return obj as unknown as TwoToTwoReaction;
+
+  for (const col of REQUIRED_NUMBER_COLUMNS) {
+    if (typeof obj[col] !== 'number') {
+      throw new Error(
+        `TwoToTwoAll row is missing or has non-numeric value for "${col}" ` +
+          `(got ${obj[col] === undefined ? 'undefined' : typeof obj[col]}). ` +
+          'Database schema may have drifted.'
+      );
+    }
+  }
+  for (const col of REQUIRED_STRING_COLUMNS) {
+    if (typeof obj[col] !== 'string') {
+      throw new Error(
+        `TwoToTwoAll row is missing or has non-string value for "${col}" ` +
+          `(got ${obj[col] === undefined ? 'undefined' : typeof obj[col]}). ` +
+          'Database schema may have drifted.'
+      );
+    }
+  }
+
+  return obj as TwoToTwoReaction;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Validate that the 13 TwoToTwoAll columns the transmutation pathway service reads (Z1..Z4, A1..A4, E1..E4, MeV) are present with the expected scalar type
- Throw an immediate, descriptive error if the schema has drifted instead of silently producing NaN / undefined downstream

## Why
The original `rowToReaction` (introduced in #182) cast `Record<string, unknown>` to `TwoToTwoReaction` via `as unknown as TwoToTwoReaction`. If `TwoToTwoAll` is ever migrated to drop or rename one of the columns this service reads, every dependent computation (`r.Z1 === fromZ`, `r.MeV`, `totalMeV`, formatted pathway strings) silently produces `undefined` / `NaN` and pathway results come back wrong with no error to surface the drift.

This is the kind of bug that is invisible in dev and only shows up once the DB version diverges in production.

## What changed
- Added `REQUIRED_NUMBER_COLUMNS` and `REQUIRED_STRING_COLUMNS` constants enumerating the 13 columns this service actually depends on
- `rowToReaction` validates each one's type and throws a descriptive `Database schema may have drifted.` error if any are missing or wrong-typed
- Removed the `as unknown as TwoToTwoReaction` double-cast

Unused columns are not validated, so non-read schema drift in unrelated columns remains harmless.

## Test plan
- [x] `npx vitest run src/services/transmutationPathwayService.test.ts` — all 13 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
