### PR TITLE
test: anchor Transmutations E2E selectors on data-testids

### DIFF
--- a/e2e/tests/transmutations.spec.ts
+++ b/e2e/tests/transmutations.spec.ts
@@ -17,12 +17,8 @@ test.describe('Transmutations Page', () => {
   });
 
   test('renders the page title and disclaimer banner', async ({ page }) => {
-    await expect(
-      page.getByRole('heading', { name: /Transmutation Pathway Explorer/i })
-    ).toBeVisible();
-    await expect(
-      page.getByText(/Documented claims, not verified mechanisms/i)
-    ).toBeVisible();
+    await expect(page.getByTestId('transmutations-heading')).toBeVisible();
+    await expect(page.getByTestId('transmutations-disclaimer')).toBeVisible();
   });
 
   test('renders documented transmutation cards', async ({ page }) => {
@@ -46,18 +42,17 @@ test.describe('Transmutations Page', () => {
     await expect(firstButton).toBeEnabled({ timeout: 30000 });
     await firstButton.click();
 
-    // Wait for either pathway results or "no pathways found" to appear.
-    // We don't assert which — both are valid outcomes for the first cut.
-    await expect(
-      page
-        .getByText(/Candidate pathways|No 1- or 2-step pathway found/i)
-        .first()
-    ).toBeVisible({ timeout: 30000 });
+    // Either pathway results or "no pathways found" is a valid outcome.
+    const pathwayResults = page.getByTestId('transmutations-pathway-results');
+    const pathwayEmpty = page.getByTestId('transmutations-pathway-empty');
+    await expect(pathwayResults.or(pathwayEmpty).first()).toBeVisible({
+      timeout: 30000,
+    });
   });
 
   test('category filter narrows the visible cards', async ({ page }) => {
     // Click the Biological filter
-    await page.getByRole('button', { name: 'Biological', exact: true }).click();
+    await page.getByTestId('transmutations-category-biological').click();
 
     // Scope assertions to transmutation card content (avoid matching against
     // the hidden lab-filter <select>'s <option> elements, which contain

--- a/src/pages/Transmutations.tsx
+++ b/src/pages/Transmutations.tsx
@@ -184,7 +184,10 @@ export default function Transmutations() {
       <div className="mb-6">
         <div className="flex items-center gap-2 mb-2">
           <FlaskConical className="w-6 h-6 text-primary-600" />
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+          <h1
+            data-testid="transmutations-heading"
+            className="text-3xl font-bold text-gray-900 dark:text-white"
+          >
             {t('transmutations.title', {
               defaultValue: 'Transmutation Pathway Explorer',
             })}
@@ -199,7 +202,10 @@ export default function Transmutations() {
       </div>
 
       {/* Disclaimer banner */}
-      <div className="card p-4 mb-6 border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20">
+      <div
+        data-testid="transmutations-disclaimer"
+        className="card p-4 mb-6 border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20"
+      >
         <div className="flex items-start gap-3">
           <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
           <div className="text-sm text-amber-900 dark:text-amber-200">
@@ -223,6 +229,7 @@ export default function Transmutations() {
       <div className="flex flex-col sm:flex-row gap-3 mb-6">
         <div className="flex flex-wrap gap-1.5">
           <FilterButton
+            testId="transmutations-category-all"
             label={t('transmutations.filterAllCategories', {
               defaultValue: 'All categories',
             })}
@@ -232,6 +239,7 @@ export default function Transmutations() {
           {CATEGORY_KEYS.map(cat => (
             <FilterButton
               key={cat}
+              testId={`transmutations-category-${cat}`}
               label={categoryLabel(cat)}
               active={categoryFilter === cat}
               onClick={() => setCategoryFilter(cat)}
@@ -543,7 +551,10 @@ function PathwayResults({ pathways, onClear }: { pathways: Pathway[]; onClear: (
   const { t } = useTranslation()
   if (pathways.length === 0) {
     return (
-      <div className="mt-4 p-4 rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
+      <div
+        data-testid="transmutations-pathway-empty"
+        className="mt-4 p-4 rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50"
+      >
         <div className="flex items-start justify-between gap-3">
           <div className="flex items-start gap-2.5 text-sm text-gray-700 dark:text-gray-300">
             <BookOpen className="w-4 h-4 flex-shrink-0 mt-0.5 text-gray-400 dark:text-gray-500" />
@@ -586,7 +597,10 @@ function PathwayResults({ pathways, onClear }: { pathways: Pathway[]; onClear: (
   }
 
   return (
-    <div className="mt-4 rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 p-3">
+    <div
+      data-testid="transmutations-pathway-results"
+      className="mt-4 rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 p-3"
+    >
       <div className="flex items-center justify-between mb-2.5">
         <p className="text-xs font-medium text-gray-700 dark:text-gray-300">
           {t('transmutations.pathwayResults.header', {
@@ -641,14 +655,17 @@ function FilterButton({
   label,
   active,
   onClick,
+  testId,
 }: {
   label: string
   active: boolean
   onClick: () => void
+  testId?: string
 }) {
   return (
     <button
       onClick={onClick}
+      data-testid={testId}
       className={`px-2.5 py-1 text-xs rounded-full border transition-colors ${
         active
           ? 'bg-primary-100 dark:bg-primary-900/30 border-primary-300 dark:border-primary-700 text-primary-700 dark:text-primary-300'


### PR DESCRIPTION
## Summary
Anchor the Transmutations E2E spec on `data-testid` selectors instead of user-visible text, so the suite keeps passing once non-English locales are exercised in CI.

## Why
The Transmutations page is fully i18n-wired (#185 added 444 translation keys). The E2E spec, however, still drives the page by translated text:

- `getByRole('heading', { name: /Transmutation Pathway Explorer/i })` — translated title
- `getByText(/Documented claims, not verified mechanisms/i)` — translated disclaimer
- `getByRole('button', { name: 'Biological', exact: true })` — translated category label
- `getByText(/Candidate pathways|No 1- or 2-step pathway found/i)` — translated pathway results header

The moment a locale-switching test or default-locale change exercises this page, all four assertions break.

## What changed
- `Transmutations.tsx`: added `data-testid` to the heading, disclaimer banner, each category `FilterButton` (`transmutations-category-{all,solid-state,biological,…}`), and both the populated and empty pathway-results containers
- `transmutations.spec.ts`: switched the four locale-sensitive assertions to `getByTestId`
- Author and nuclide names (Iwamura, Vysotskii, Cs-133, Pr-141) are not translated and remain on `getByText`

## Test plan
- [ ] CI green on Chromium and Firefox
- [ ] Suite still passes when a future PR adds locale-switching coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
